### PR TITLE
Add real-time pending mail dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Die Vite-Entwicklungsumgebung proxied standardmäßig auf `localhost:5173`. Pass
 | `POST`  | `/api/mode`         | Setzt den Move-Modus – Body `{ "mode": "CONFIRM" }` |
 | `GET`   | `/api/folders`      | Listet verfügbare IMAP-Ordner |
 | `GET`   | `/api/suggestions`  | Liefert offene Vorschläge inkl. Ranking |
+| `GET`   | `/api/pending`      | Übersicht offener, noch nicht verarbeiteter Nachrichten |
 | `POST`  | `/api/decide`       | Nimmt Entscheidung für einen Vorschlag entgegen |
 | `POST`  | `/api/move`         | Verschiebt oder simuliert eine einzelne Nachricht |
 | `POST`  | `/api/move/bulk`    | Führt mehrere Move-Requests nacheinander aus |

--- a/backend/pending.py
+++ b/backend/pending.py
@@ -1,0 +1,81 @@
+"""Helpers to compute pending (unprocessed) mailbox items."""
+
+from __future__ import annotations
+
+import asyncio
+import email
+from dataclasses import dataclass
+from email import policy
+from typing import List, Sequence
+
+from database import known_suggestion_uids, processed_uids_by_folder
+from mailbox import fetch_recent_messages
+from settings import S
+from utils import subject_from
+
+
+@dataclass
+class PendingMail:
+    """Lightweight representation of a message without AI processing."""
+
+    message_uid: str
+    folder: str
+    subject: str
+    from_addr: str | None
+    date: str | None
+
+
+@dataclass
+class PendingOverview:
+    """Aggregated statistics about pending messages."""
+
+    total_messages: int
+    processed_count: int
+    pending: List[PendingMail]
+
+    @property
+    def pending_count(self) -> int:
+        return len(self.pending)
+
+    @property
+    def pending_ratio(self) -> float:
+        if self.total_messages == 0:
+            return 0.0
+        return self.pending_count / self.total_messages
+
+
+async def load_pending_overview(folders: Sequence[str] | None = None) -> PendingOverview:
+    """Return metadata about messages that have not been processed by the AI yet."""
+
+    target_folders: List[str] = [str(folder) for folder in folders] if folders else [S.IMAP_INBOX]
+    raw_payloads = await asyncio.to_thread(fetch_recent_messages, target_folders)
+    processed_map = processed_uids_by_folder(target_folders)
+    known_suggestions = known_suggestion_uids()
+
+    pending_entries: List[PendingMail] = []
+    total_messages = 0
+
+    for folder, messages in raw_payloads.items():
+        total_messages += len(messages)
+        processed_for_folder = processed_map.get(folder, set())
+        for uid, payload in messages.items():
+            uid_str = str(uid)
+            if uid_str in processed_for_folder or uid_str in known_suggestions:
+                continue
+            if not payload:
+                continue
+            msg = email.message_from_bytes(payload, policy=policy.default)
+            subject, from_addr = subject_from(msg)
+            pending_entries.append(
+                PendingMail(
+                    message_uid=uid_str,
+                    folder=folder,
+                    subject=subject or "",
+                    from_addr=from_addr or None,
+                    date=str(msg.get("Date")) if msg.get("Date") else None,
+                )
+            )
+
+    pending_entries.sort(key=lambda item: (item.folder, item.message_uid))
+    processed_count = max(total_messages - len(pending_entries), 0)
+    return PendingOverview(total_messages=total_messages, processed_count=processed_count, pending=pending_entries)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,7 +8,9 @@ import {
   setMode,
 } from './api'
 import SuggestionCard from './components/SuggestionCard'
+import PendingOverviewPanel from './components/PendingOverviewPanel'
 import { useSuggestions } from './store/useSuggestions'
+import { usePendingOverview } from './store/usePendingOverview'
 
 const modeOptions: MoveMode[] = ['DRY_RUN', 'CONFIRM', 'AUTO']
 
@@ -30,6 +32,7 @@ const toMessage = (err: unknown) => (err instanceof Error ? err.message : String
 
 export default function App(): JSX.Element {
   const { data: suggestions, loading, error, refresh } = useSuggestions()
+  const { data: pendingOverview, loading: pendingLoading, error: pendingError } = usePendingOverview()
   const [mode, setModeState] = useState<MoveMode>('DRY_RUN')
   const [folders, setFolders] = useState<string[]>([])
   const [status, setStatus] = useState<StatusMessage | null>(null)
@@ -126,6 +129,8 @@ export default function App(): JSX.Element {
       )}
 
       {error && <div className="status-banner error">{error}</div>}
+
+      <PendingOverviewPanel overview={pendingOverview} loading={pendingLoading} error={pendingError} />
 
       <section className="folders">
         <h2>Überwachte Ordner</h2>

--- a/frontend/src/components/PendingOverviewPanel.tsx
+++ b/frontend/src/components/PendingOverviewPanel.tsx
@@ -1,0 +1,71 @@
+import React, { useMemo } from 'react'
+import { PendingOverview } from '../api'
+
+interface PendingOverviewPanelProps {
+  overview: PendingOverview | null
+  loading: boolean
+  error: string | null
+}
+
+const formatPercent = (ratio: number) => `${(ratio * 100).toFixed(1)} %`
+
+const formatSubject = (subject: string) => (subject.trim().length > 0 ? subject.trim() : '(kein Betreff)')
+
+const formatSender = (sender?: string | null) => sender || 'Unbekannter Absender'
+
+export default function PendingOverviewPanel({ overview, loading, error }: PendingOverviewPanelProps): JSX.Element {
+  const pendingCount = overview?.pending_count ?? 0
+  const totalMessages = overview?.total_messages ?? 0
+  const processedCount = overview?.processed_count ?? 0
+  const ratioText = useMemo(() => formatPercent(overview?.pending_ratio ?? 0), [overview?.pending_ratio])
+
+  return (
+    <section className="pending-overview">
+      <div className="pending-header">
+        <div>
+          <h2>Offene Mails ohne KI-Vorschlag</h2>
+          <p className="pending-subline">
+            Übersicht über Nachrichten, die noch nicht verarbeitet wurden.
+          </p>
+        </div>
+        <div className="pending-metrics">
+          <div className="pending-metric">
+            <span className="label">Offen</span>
+            <strong>{pendingCount}</strong>
+            <span className="muted">{ratioText}</span>
+          </div>
+          <div className="pending-metric">
+            <span className="label">Bereits verarbeitet</span>
+            <strong>{processedCount}</strong>
+            <span className="muted">von {totalMessages}</span>
+          </div>
+        </div>
+      </div>
+
+      {error && <div className="status-banner error">{error}</div>}
+
+      {loading && <div className="pending-placeholder">Live-Status wird geladen…</div>}
+
+      {!loading && !pendingCount && !error && (
+        <div className="pending-placeholder">Alle aktuellen Nachrichten wurden bereits analysiert.</div>
+      )}
+
+      {!loading && pendingCount > 0 && (
+        <ul className="pending-list">
+          {overview?.pending.map(item => (
+            <li key={`${item.folder}-${item.message_uid}`} className="pending-item">
+              <div className="pending-item-header">
+                <span className="pending-subject">{formatSubject(item.subject)}</span>
+                <span className="pending-folder">{item.folder}</span>
+              </div>
+              <div className="pending-item-meta">
+                <span>{formatSender(item.from_addr)}</span>
+                {item.date && <span className="date">{item.date}</span>}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  )
+}

--- a/frontend/src/store/usePendingOverview.ts
+++ b/frontend/src/store/usePendingOverview.ts
@@ -1,0 +1,76 @@
+import { useEffect, useState } from 'react'
+import { PendingOverview, StreamEvent, getPendingOverview, openStream } from '../api'
+
+export interface PendingOverviewState {
+  data: PendingOverview | null
+  loading: boolean
+  error: string | null
+}
+
+export function usePendingOverview(): PendingOverviewState {
+  const [data, setData] = useState<PendingOverview | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let active = true
+    const loadInitial = async () => {
+      try {
+        const snapshot = await getPendingOverview()
+        if (active) {
+          setData(snapshot)
+          setError(null)
+        }
+      } catch (err) {
+        if (active) {
+          setError(err instanceof Error ? err.message : 'Überblick konnte nicht geladen werden.')
+        }
+      } finally {
+        if (active) {
+          setLoading(false)
+        }
+      }
+    }
+
+    void loadInitial()
+
+    let socket: WebSocket | null = null
+    try {
+      socket = openStream((event: StreamEvent) => {
+        if (!active) return
+        if (event.type === 'pending_overview') {
+          setData(event.payload)
+          setError(null)
+        } else if (event.type === 'pending_error') {
+          setError(event.error)
+        }
+      })
+    } catch (err) {
+      if (active) {
+        setError(err instanceof Error ? err.message : 'Echtzeitverbindung konnte nicht aufgebaut werden.')
+      }
+    }
+
+    if (socket) {
+      socket.onerror = () => {
+        if (active) {
+          setError('Live-Updates nicht verfügbar (WebSocket-Fehler).')
+        }
+      }
+      socket.onclose = () => {
+        if (active) {
+          setError(prev => prev ?? 'Verbindung zur Echtzeitübersicht wurde beendet.')
+        }
+      }
+    }
+
+    return () => {
+      active = false
+      if (socket) {
+        socket.close()
+      }
+    }
+  }, [])
+
+  return { data, loading, error }
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -135,7 +135,8 @@ button.link {
 }
 
 .folders,
-.suggestions {
+.suggestions,
+.pending-overview {
   background: rgba(255, 255, 255, 0.8);
   border-radius: 20px;
   padding: 20px 24px;
@@ -143,7 +144,8 @@ button.link {
 }
 
 .folders h2,
-.suggestions h2 {
+.suggestions h2,
+.pending-overview h2 {
   margin-top: 0;
 }
 
@@ -151,6 +153,113 @@ button.link {
   padding: 24px;
   text-align: center;
   color: #52606d;
+}
+
+.pending-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.pending-subline {
+  margin: 4px 0 0;
+  color: #52606d;
+  font-size: 14px;
+}
+
+.pending-metrics {
+  display: flex;
+  gap: 12px;
+  align-items: stretch;
+}
+
+.pending-metric {
+  background: #eef2ff;
+  border-radius: 16px;
+  padding: 12px 16px;
+  min-width: 120px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.pending-metric .label {
+  text-transform: uppercase;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  color: #4f46e5;
+  font-weight: 600;
+}
+
+.pending-metric strong {
+  font-size: 24px;
+  color: #111827;
+}
+
+.pending-metric .muted {
+  font-size: 12px;
+  color: #4b5563;
+}
+
+.pending-placeholder {
+  padding: 18px;
+  text-align: center;
+  background: #f8fafc;
+  border-radius: 14px;
+  color: #52606d;
+}
+
+.pending-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.pending-item {
+  background: white;
+  border-radius: 16px;
+  padding: 14px 16px;
+  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.pending-item-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.pending-subject {
+  font-weight: 600;
+  color: #111827;
+}
+
+.pending-folder {
+  font-size: 12px;
+  background: #e0e7ff;
+  color: #3730a3;
+  padding: 4px 10px;
+  border-radius: 999px;
+}
+
+.pending-item-meta {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  color: #4b5563;
+  font-size: 13px;
+}
+
+.pending-item-meta .date {
+  font-style: italic;
 }
 
 .suggestions-header {
@@ -289,5 +398,14 @@ code {
   button.primary,
   button.ghost {
     width: 100%;
+  }
+
+  .pending-metrics {
+    width: 100%;
+    flex-direction: column;
+  }
+
+  .pending-header {
+    flex-direction: column;
   }
 }


### PR DESCRIPTION
## Summary
- add backend helpers and endpoint to expose pending messages that still await AI processing
- stream the pending overview via the existing websocket and surface it in the frontend
- render a live dashboard with counters and a list of pending mails including styling updates

## Testing
- python -m compileall backend
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e157b030dc8328b1060a1ff5c0b738