### PR TITLE
Enhance folder selection and proposal workflows

### DIFF
--- a/backend/classifier.py
+++ b/backend/classifier.py
@@ -1,11 +1,16 @@
 
 from __future__ import annotations
 
+import json
+import logging
 from typing import Any, Dict, Iterable, List, Sequence, Tuple
 
 import httpx
 
 from settings import S
+
+
+logger = logging.getLogger(__name__)
 
 
 def _cosine(a: Sequence[float], b: Sequence[float] | None) -> float:
@@ -21,7 +26,7 @@ def build_embedding_prompt(subject: str, sender: str, body: str) -> str:
 
     header_lines = [
         "Du bist ein Assistent, der E-Mails für eine Ordnerklassifikation analysiert.",
-        "Erstelle eine aussagekräftige semantische Repräsentation auf Basis von Betreff, Absender und Kerninhalten.",
+        "Erstelle eine kompakte semantische Repräsentation aus Betreff, Absender und Kerninhalt.",
     ]
     hint = S.EMBED_PROMPT_HINT.strip()
     if hint:
@@ -30,8 +35,8 @@ def build_embedding_prompt(subject: str, sender: str, body: str) -> str:
     email_lines = [
         f"Betreff: {subject or '-'}",
         f"Von: {sender or '-'}",
-        "Inhalt:",
-        body.strip() or "(kein Text vorhanden)",
+        "Inhalt (gekürzt):",
+        (body.strip() or "(kein Text vorhanden)")[: S.EMBED_PROMPT_MAX_CHARS],
     ]
 
     prompt = "\n".join([*header_lines, "", *email_lines])
@@ -58,6 +63,151 @@ def score_profiles(embedding: Sequence[float], profiles: Iterable[Dict[str, Any]
     return scores[: S.MAX_SUGGESTIONS]
 
 
+def _format_ranked_for_prompt(ranked: List[Tuple[str, float]]) -> str:
+    if not ranked:
+        return "Keine bisherigen Zuordnungen verfügbar."
+    rows = [
+        f"- {name}: Score {score:.2f}"
+        for name, score in ranked[: S.MAX_SUGGESTIONS]
+    ]
+    return "\n".join(rows)
+
+
+def build_classification_prompt(
+    subject: str,
+    sender: str,
+    body: str,
+    ranked: List[Tuple[str, float]],
+) -> List[Dict[str, str]]:
+    """Return chat messages instructing the LLM to refine folder suggestions."""
+
+    system_prompt = (
+        "Du bist ein Assistent, der eingehende E-Mails passenden Ordnern zuordnet. "
+        "Nutze Score-Werte als Hinweis, darfst sie aber anpassen, wenn der Inhalt besser passt. "
+        "Falls kein Ordner passt, schlage genau einen neuen Unterordner vor. "
+        "Antwort ausschließlich als gültiges JSON mit den Schlüsseln 'ranked' und 'proposal'."
+    )
+
+    hint = S.EMBED_PROMPT_HINT.strip()
+    if hint:
+        system_prompt += f" Zusätzliche betriebliche Vorgabe: {hint}."
+
+    user_prompt = (
+        "E-Mail-Daten:\n"
+        f"Betreff: {subject or '-'}\n"
+        f"Von: {sender or '-'}\n"
+        "Textauszug:\n"
+        f"{body[: S.EMBED_PROMPT_MAX_CHARS]}\n\n"
+        "Vorliegende Ordner-Scores:\n"
+        f"{_format_ranked_for_prompt(ranked)}\n\n"
+        "Schema (JSON):\n"
+        '{"ranked": [{"name": "Ordner", "confidence": 0.0-1.0, "reason": "Kurzbegründung"}],'
+        ' "proposal": {"parent": "Überordner", "name": "Neuer Unterordner", "reason": "Warum"} oder null}\n'
+        "Maximal drei Einträge in 'ranked'."
+    )
+
+    return [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": user_prompt},
+    ]
+
+
+async def _chat(messages: List[Dict[str, str]]) -> Dict[str, Any]:
+    async with httpx.AsyncClient(timeout=90) as client:
+        response = await client.post(
+            f"{S.OLLAMA_HOST}/api/chat",
+            json={"model": S.CLASSIFIER_MODEL, "messages": messages, "format": "json"},
+        )
+        response.raise_for_status()
+        return response.json()
+
+
+def _fallback_ranked(ranked: List[Tuple[str, float]]) -> List[Dict[str, Any]]:
+    return [
+        {"name": name, "score": float(score)}
+        for name, score in ranked[: S.MAX_SUGGESTIONS]
+    ]
+
+
+def _parse_ranked(payload: Any, fallback: List[Tuple[str, float]]) -> List[Dict[str, Any]]:
+    ranked: List[Dict[str, Any]] = []
+    if isinstance(payload, list):
+        for entry in payload:
+            if not isinstance(entry, dict):
+                continue
+            name = entry.get("name")
+            if not isinstance(name, str) or not name.strip():
+                continue
+            confidence_raw = entry.get("confidence", entry.get("score", 0.0))
+            try:
+                confidence = float(confidence_raw)
+            except (TypeError, ValueError):
+                confidence = 0.0
+            item: Dict[str, Any] = {
+                "name": name.strip(),
+                "score": max(0.0, min(confidence, 1.0)),
+            }
+            reason = entry.get("reason")
+            if isinstance(reason, str) and reason.strip():
+                item["reason"] = reason.strip()
+            ranked.append(item)
+    if ranked:
+        return ranked[: S.MAX_SUGGESTIONS]
+    return _fallback_ranked(fallback)
+
+
+def _normalise_proposal(proposal: Any, parent_hint: str | None, top_score: float) -> Dict[str, Any] | None:
+    if isinstance(proposal, dict):
+        parent = str(proposal.get("parent", parent_hint or "")).strip() or parent_hint or "Projects"
+        name = str(proposal.get("name", "")).strip()
+        reason = str(proposal.get("reason", "")) or "automatischer Vorschlag"
+        if name:
+            full_path = f"{parent}/{name}".strip("/")
+            return {
+                "parent": parent,
+                "name": name,
+                "reason": reason,
+                "full_path": full_path,
+                "status": "pending",
+                "score_hint": float(top_score),
+            }
+    return None
+
+
+async def classify_with_model(
+    subject: str,
+    sender: str,
+    body: str,
+    ranked: List[Tuple[str, float]],
+    parent_hint: str | None,
+) -> Tuple[List[Dict[str, Any]], Dict[str, Any] | None]:
+    if not S.CLASSIFIER_MODEL:
+        return _fallback_ranked(ranked), None
+
+    messages = build_classification_prompt(subject, sender, body, ranked)
+    try:
+        response = await _chat(messages)
+    except Exception as exc:  # pragma: no cover - network interaction
+        logger.warning("Ollama Klassifikation fehlgeschlagen: %s", exc)
+        return _fallback_ranked(ranked), None
+
+    content = response.get("message", {}).get("content")
+    if not content:
+        return _fallback_ranked(ranked), None
+
+    try:
+        parsed = json.loads(content)
+    except json.JSONDecodeError as exc:  # pragma: no cover - depends on LLM output
+        logger.warning("Konnte Ollama-Antwort nicht parsen: %s", exc)
+        return _fallback_ranked(ranked), None
+
+    refined_ranked = _parse_ranked(parsed.get("ranked"), ranked)
+    proposal = _normalise_proposal(
+        parsed.get("proposal"), parent_hint, ranked[0][1] if ranked else 0.0
+    )
+    return refined_ranked, proposal
+
+
 async def rank_with_profiles(text: str, profiles: List[Dict[str, Any]]) -> List[Tuple[str, float]]:
     prompt = build_embedding_prompt("", "", text)
     embedding = await embed(prompt)
@@ -68,9 +218,15 @@ async def propose_new_folder_if_needed(
     top_score: float, parent_hint: str | None = None
 ) -> Dict[str, Any] | None:
     if top_score < S.MIN_NEW_FOLDER_SCORE:
+        parent = parent_hint or "Projects"
+        name = "_auto/topic"
+        full_path = f"{parent}/{name}".strip("/")
         return {
-            "parent": parent_hint or "Projects",
-            "name": "_auto/topic",
-            "reason": "niedrige Ähnlichkeit",
+            "parent": parent,
+            "name": name,
+            "reason": "geringe Übereinstimmung mit bekannten Ordnern",
+            "full_path": full_path,
+            "status": "pending",
+            "score_hint": float(top_score),
         }
     return None

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -3,12 +3,16 @@ export type MoveMode = 'DRY_RUN' | 'CONFIRM' | 'AUTO'
 export interface SuggestionScore {
   name: string
   score: number
+  reason?: string
 }
 
 export interface NewFolderProposal {
   parent: string
   name: string
   reason: string
+  full_path?: string
+  status?: 'pending' | 'accepted' | 'rejected'
+  score_hint?: number
 }
 
 export interface Suggestion {
@@ -60,6 +64,16 @@ export interface RescanResponse {
   new_suggestions: number
 }
 
+export interface FolderSelectionResponse {
+  available: string[]
+  selected: string[]
+}
+
+export interface ProposalDecisionResponse {
+  ok: boolean
+  proposal: NewFolderProposal | null
+}
+
 export type StreamEvent =
   | { type: 'hello'; msg: string }
   | { type: 'pending_overview'; payload: PendingOverview }
@@ -92,7 +106,7 @@ export async function setMode(mode: MoveMode): Promise<ModeResponse> {
   return request('/api/mode', { method: 'POST', body: JSON.stringify({ mode }) })
 }
 
-export async function getFolders(): Promise<string[]> {
+export async function getFolders(): Promise<FolderSelectionResponse> {
   return request('/api/folders')
 }
 
@@ -123,6 +137,20 @@ export async function rescan(folders?: string[]): Promise<RescanResponse> {
   return request<RescanResponse>('/api/rescan', {
     method: 'POST',
     body: JSON.stringify({ folders }),
+  })
+}
+
+export async function updateFolderSelection(folders: string[]): Promise<FolderSelectionResponse> {
+  return request('/api/folders/selection', {
+    method: 'POST',
+    body: JSON.stringify({ folders }),
+  })
+}
+
+export async function decideProposal(message_uid: string, accept: boolean): Promise<ProposalDecisionResponse> {
+  return request('/api/proposal', {
+    method: 'POST',
+    body: JSON.stringify({ message_uid, accept }),
   })
 }
 

--- a/frontend/src/components/FolderSelectionPanel.tsx
+++ b/frontend/src/components/FolderSelectionPanel.tsx
@@ -1,0 +1,108 @@
+import React, { useEffect, useMemo, useState } from 'react'
+
+interface Props {
+  available: string[]
+  draft: string[]
+  onDraftChange: (folders: string[]) => void
+  onSave: () => Promise<void> | void
+  onReload: () => Promise<void> | void
+  loading: boolean
+  saving: boolean
+}
+
+const normalize = (folders: string[]): string[] => Array.from(new Set(folders))
+
+export default function FolderSelectionPanel({
+  available,
+  draft,
+  onDraftChange,
+  onSave,
+  onReload,
+  loading,
+  saving,
+}: Props): JSX.Element {
+  const [filter, setFilter] = useState('')
+
+  useEffect(() => {
+    setFilter('')
+  }, [available.join('|')])
+
+  const filtered = useMemo(() => {
+    const trimmed = filter.trim().toLowerCase()
+    if (!trimmed) {
+      return available
+    }
+    return available.filter(folder => folder.toLowerCase().includes(trimmed))
+  }, [available, filter])
+
+  const toggleFolder = (folder: string) => {
+    const exists = draft.includes(folder)
+    const next = exists ? draft.filter(item => item !== folder) : [...draft, folder]
+    onDraftChange(normalize(next))
+  }
+
+  const selectAll = () => onDraftChange(normalize(available))
+  const selectNone = () => onDraftChange([])
+
+  return (
+    <section className="folder-panel">
+      <div className="panel-header">
+        <h2>Überwachte Ordner</h2>
+        <div className="panel-actions">
+          <button type="button" className="link" onClick={onReload} disabled={loading || saving}>
+            Neu laden
+          </button>
+        </div>
+      </div>
+      <p className="panel-description">
+        Wähle die IMAP-Ordner aus, die beim Scan berücksichtigt werden sollen. Die Auswahl wird gespeichert.
+      </p>
+      <div className="folder-toolbar">
+        <input
+          type="search"
+          placeholder="Ordner filtern"
+          value={filter}
+          onChange={event => setFilter(event.target.value)}
+          aria-label="Ordner filtern"
+          disabled={loading}
+        />
+        <div className="toolbar-buttons">
+          <button type="button" onClick={selectAll} disabled={loading || !available.length}>
+            Alle
+          </button>
+          <button type="button" onClick={selectNone} disabled={loading}>
+            Keine
+          </button>
+        </div>
+      </div>
+      {loading && <div className="placeholder">Ordner werden geladen…</div>}
+      {!loading && !available.length && <div className="placeholder">Keine Ordner verfügbar.</div>}
+      {!loading && available.length > 0 && (
+        <ul className="folder-list">
+          {filtered.map(folder => {
+            const checked = draft.includes(folder)
+            return (
+              <li key={folder}>
+                <label className={checked ? 'checked' : undefined}>
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    onChange={() => toggleFolder(folder)}
+                    disabled={saving}
+                  />
+                  <span>{folder}</span>
+                </label>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+      <div className="folder-footer">
+        <div className="selection-count">Ausgewählt: {draft.length}</div>
+        <button type="button" className="primary" onClick={onSave} disabled={saving}>
+          {saving ? 'Speichere…' : 'Auswahl speichern'}
+        </button>
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -134,7 +134,7 @@ button.link {
   color: #c81e1e;
 }
 
-.folders,
+.folder-panel,
 .suggestions,
 .pending-overview {
   background: rgba(255, 255, 255, 0.8);
@@ -143,10 +143,96 @@ button.link {
   box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
 }
 
-.folders h2,
+.folder-panel h2,
 .suggestions h2,
 .pending-overview h2 {
   margin-top: 0;
+}
+
+.folder-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.panel-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.panel-description {
+  margin: 0;
+  color: #52606d;
+  font-size: 14px;
+}
+
+.folder-toolbar {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.folder-toolbar input {
+  flex: 1 1 220px;
+  min-width: 160px;
+  padding: 8px 12px;
+  border-radius: 10px;
+  border: 1px solid #cbd5e1;
+  background: #f8fafc;
+}
+
+.toolbar-buttons {
+  display: flex;
+  gap: 8px;
+}
+
+.folder-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 6px;
+  max-height: 240px;
+  overflow: auto;
+}
+
+.folder-list li label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border-radius: 10px;
+  background: #f8fafc;
+  transition: background 0.2s ease;
+}
+
+.folder-list li label.checked {
+  background: #e0ecff;
+}
+
+.folder-list li input {
+  margin: 0;
+}
+
+.folder-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.selection-count {
+  font-size: 13px;
+  color: #52606d;
 }
 
 .placeholder {
@@ -336,8 +422,45 @@ button.link {
   font-size: 13px;
   background: #fff7ed;
   border-radius: 12px;
-  padding: 10px 12px;
+  padding: 12px;
   color: #92400e;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.proposal-text {
+  line-height: 1.4;
+}
+
+.proposal-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.proposal-status {
+  font-size: 12px;
+  font-weight: 600;
+  align-self: flex-start;
+  padding: 6px 12px;
+  border-radius: 999px;
+}
+
+.proposal-status.accepted {
+  background: #ecfdf5;
+  color: #0f766e;
+}
+
+.proposal-status.rejected {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.score-reason {
+  font-size: 12px;
+  color: #4b5563;
+  margin-left: 6px;
 }
 
 .target-input {


### PR DESCRIPTION
## Summary
- add persisted IMAP folder selection endpoints and reuse them in rescans and pending metrics
- refine Ollama classification prompts to produce ranked reasons and actionable folder proposals, including IMAP folder creation
- expose new controls in the React UI for folder selection and proposal approval, with updated styling

## Testing
- python -m compileall backend
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e15e665c9083289a358180cd1cf90d