### PR TITLE
Fix Ollama container health check

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     ports: ["11434:11434"]
     volumes: [ "ollama:/root/.ollama" ]
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:11434/api/tags"]
+      test: ["CMD-SHELL", "ollama list >/dev/null 2>&1"]
       interval: 10s
       timeout: 5s
       retries: 30


### PR DESCRIPTION
## Summary
- replace the docker healthcheck for the Ollama service with an ollama CLI call so it no longer depends on curl inside the container

## Testing
- docker compose build *(fails: docker not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e17a3b0e0883288b4e6d28eea8bb97