### PR TITLE
Handle Ollama connection errors in worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ DEV_MODE=false
   setzen, ohne den Code anzupassen. Sowohl Embedding- als auch Klassifikationsprompt greifen auf den Hinweis zu.
 - `EMBED_PROMPT_MAX_CHARS` limitiert die Länge des Prompts, um Speicherbedarf und Antwortzeiten
   zu kontrollieren.
+- Verbindungsfehler (`httpx.ConnectError` oder Logeintrag `Ollama Embedding fehlgeschlagen`) deuten
+  auf einen nicht erreichbaren Ollama-Host hin. Stelle sicher, dass `OLLAMA_HOST` auf `http://ollama:11434`
+  zeigt, wenn alle Dienste via Docker Compose laufen. Bei lokal gestarteten Komponenten außerhalb
+  von Docker muss der Wert auf `http://localhost:11434` oder die entsprechende IP des Hosts gesetzt werden.
 
 ### Schutz- und Monitoring-Einstellungen
 

--- a/backend/classifier.py
+++ b/backend/classifier.py
@@ -44,27 +44,34 @@ def build_embedding_prompt(subject: str, sender: str, body: str) -> str:
 
 
 async def embed(prompt: str) -> List[float]:
-    async with httpx.AsyncClient(timeout=60) as client:
-        response = await client.post(
-            f"{S.OLLAMA_HOST}/api/embed",
-            json={
-                "model": S.EMBED_MODEL,
-                "input": [prompt[: S.EMBED_PROMPT_MAX_CHARS]],
-            },
+    try:
+        async with httpx.AsyncClient(timeout=60) as client:
+            response = await client.post(
+                f"{S.OLLAMA_HOST}/api/embed",
+                json={
+                    "model": S.EMBED_MODEL,
+                    "input": [prompt[: S.EMBED_PROMPT_MAX_CHARS]],
+                },
+            )
+            response.raise_for_status()
+    except httpx.HTTPError as exc:  # pragma: no cover - network interaction
+        logger.warning(
+            "Ollama Embedding fehlgeschlagen (%s): %s", S.OLLAMA_HOST, exc
         )
-        response.raise_for_status()
-        data = response.json()
-        embedding = data.get("embedding")
-        if isinstance(embedding, list):
-            if embedding and isinstance(embedding[0], list):
-                return embedding[0]
-            return embedding
-        embeddings = data.get("embeddings")
-        if isinstance(embeddings, list) and embeddings:
-            first = embeddings[0]
-            if isinstance(first, list):
-                return first
         return []
+
+    data = response.json()
+    embedding = data.get("embedding")
+    if isinstance(embedding, list):
+        if embedding and isinstance(embedding[0], list):
+            return embedding[0]
+        return embedding
+    embeddings = data.get("embeddings")
+    if isinstance(embeddings, list) and embeddings:
+        first = embeddings[0]
+        if isinstance(first, list):
+            return first
+    return []
 
 
 def score_profiles(embedding: Sequence[float], profiles: Iterable[Dict[str, Any]]) -> List[Tuple[str, float]]:


### PR DESCRIPTION
## Summary
- guard embedding calls against Ollama connection issues and log helpful context for operators
- document how to set OLLAMA_HOST for Docker and local setups to resolve ConnectError problems

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68e1820221c48328bb03c38c9bddff0f