### PR TITLE
Improve pending overview and surface AI tag insights

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ DEV_MODE=false
 - `IMAP_PROTECTED_TAG` kennzeichnet Nachrichten, die vom Worker übersprungen werden sollen (z. B. manuell markierte Threads).
 - `IMAP_PROCESSED_TAG` wird nach erfolgreicher Verarbeitung automatisch gesetzt und verhindert erneute Scans.
 - `INIT_RUN` setzt beim nächsten Start die Datenbank zurück (Tabellen werden geleert, SQLite-Dateien neu angelegt).
-- `PENDING_LIST_LIMIT` bestimmt die maximale Anzahl angezeigter Einträge im Pending-Dashboard (0 blendet die Tabelle aus).
+- `PENDING_LIST_LIMIT` bestimmt die maximale Anzahl angezeigter Einträge im Pending-Dashboard (0 deaktiviert die Begrenzung).
 - `DEV_MODE` aktiviert zusätzliche Debug-Ausgaben im Backend sowie das Dev-Panel im Frontend.
   Optional kann das Frontend per `VITE_DEV_MODE=true` (in `frontend/.env`) unabhängig vom Backend gestartet werden.
 
@@ -139,6 +139,7 @@ Die Vite-Entwicklungsumgebung proxied standardmäßig auf `localhost:5173`. Pass
 | `POST`  | `/api/folders/selection` | Speichert die zu überwachenden IMAP-Ordner |
 | `GET`   | `/api/suggestions`  | Liefert Vorschläge inkl. Ranking; mit `?include=all` auch bereits entschiedene |
 | `GET`   | `/api/pending`      | Übersicht offener, noch nicht verarbeiteter Nachrichten |
+| `GET`   | `/api/tags`         | Aggregierte KI-Tags inkl. Beispiele für die weitere Verarbeitung |
 | `GET`   | `/api/ollama`       | Aktuelle Erreichbarkeit des Ollama-Hosts und Modellstatus |
 | `GET`   | `/api/config`       | Liefert Laufzeitkonfiguration (Dev-Modus, Tag-Namen, Listenlimit) |
 | `POST`  | `/api/decide`       | Nimmt Entscheidung für einen Vorschlag entgegen |

--- a/backend/tags.py
+++ b/backend/tags.py
@@ -1,0 +1,126 @@
+"""Aggregation helpers for AI-generated tag suggestions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+from typing import Dict, List, Sequence
+
+from database import get_session
+from models import Suggestion
+from sqlmodel import select
+
+
+@dataclass
+class TagExample:
+    """Lightweight preview of a suggestion that proposed a specific tag."""
+
+    message_uid: str
+    subject: str
+    from_addr: str | None
+    folder: str | None
+    date: str | None
+
+
+@dataclass
+class TagSuggestion:
+    """Aggregated representation of a tag across multiple suggestions."""
+
+    tag: str
+    occurrences: int
+    last_seen: datetime | None
+    examples: List[TagExample] = field(default_factory=list)
+
+    def serialisable_examples(self) -> List[Dict[str, str | None]]:
+        return [
+            {
+                "message_uid": example.message_uid,
+                "subject": example.subject,
+                "from_addr": example.from_addr,
+                "folder": example.folder,
+                "date": example.date,
+            }
+            for example in self.examples
+        ]
+
+
+def _normalise_tag(tag: str) -> str | None:
+    cleaned = tag.strip()
+    return cleaned or None
+
+
+def _parse_mail_date(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = parsedate_to_datetime(value)
+    except (TypeError, ValueError, IndexError):  # pragma: no cover - depends on email header format
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _deduplicate_tags(tags: Sequence[str] | None) -> List[str]:
+    result: List[str] = []
+    if not tags:
+        return result
+    for item in tags:
+        if not isinstance(item, str):
+            continue
+        normalised = _normalise_tag(item)
+        if not normalised or normalised in result:
+            continue
+        result.append(normalised)
+    return result
+
+
+def _append_example(aggregate: TagSuggestion, suggestion: Suggestion, limit: int) -> None:
+    if len(aggregate.examples) >= limit:
+        return
+    aggregate.examples.append(
+        TagExample(
+            message_uid=suggestion.message_uid,
+            subject=(suggestion.subject or "").strip() or "(kein Betreff)",
+            from_addr=(suggestion.from_addr or None),
+            folder=(suggestion.src_folder or None),
+            date=suggestion.date,
+        )
+    )
+
+
+def load_tag_suggestions(max_examples: int = 3, limit: int = 60) -> List[TagSuggestion]:
+    """Aggregate all AI generated tags grouped by label."""
+
+    with get_session() as session:
+        rows: List[Suggestion] = list(
+            session.exec(select(Suggestion).order_by(Suggestion.id.desc()))
+        )
+
+    aggregates: Dict[str, TagSuggestion] = {}
+    for suggestion in rows:
+        unique_tags = _deduplicate_tags(suggestion.tags)
+        if not unique_tags:
+            continue
+        seen_date = _parse_mail_date(suggestion.date)
+        for tag in unique_tags:
+            bucket = aggregates.get(tag)
+            if not bucket:
+                bucket = TagSuggestion(tag=tag, occurrences=0, last_seen=seen_date, examples=[])
+                aggregates[tag] = bucket
+            bucket.occurrences += 1
+            if seen_date and (bucket.last_seen is None or seen_date > bucket.last_seen):
+                bucket.last_seen = seen_date
+            _append_example(bucket, suggestion, max_examples)
+
+    ordered = sorted(
+        aggregates.values(),
+        key=lambda item: (
+            -(item.occurrences),
+            item.last_seen.timestamp() if item.last_seen else float("-inf"),
+            item.tag.lower(),
+        ),
+    )
+
+    return ordered[:limit]

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -60,6 +60,22 @@ export interface PendingOverview {
   pending: PendingMail[]
   displayed_pending?: number
   list_limit?: number
+  limit_active?: boolean
+}
+
+export interface TagExample {
+  message_uid: string
+  subject: string
+  from_addr?: string | null
+  folder?: string | null
+  date?: string | null
+}
+
+export interface TagSuggestion {
+  tag: string
+  occurrences: number
+  last_seen?: string | null
+  examples: TagExample[]
 }
 
 export interface OllamaModelStatus {
@@ -209,6 +225,10 @@ export async function getSuggestions(scope: SuggestionScope = 'open'): Promise<S
 
 export async function getPendingOverview(): Promise<PendingOverview> {
   return request<PendingOverview>('/api/pending')
+}
+
+export async function getTagSuggestions(): Promise<TagSuggestion[]> {
+  return request<TagSuggestion[]>('/api/tags')
 }
 
 export async function getAppConfig(): Promise<AppConfig> {

--- a/frontend/src/components/PendingOverviewPanel.tsx
+++ b/frontend/src/components/PendingOverviewPanel.tsx
@@ -18,8 +18,7 @@ export default function PendingOverviewPanel({ overview, loading, error }: Pendi
   const totalMessages = overview?.total_messages ?? 0
   const processedCount = overview?.processed_count ?? 0
   const ratioText = useMemo(() => formatPercent(overview?.pending_ratio ?? 0), [overview?.pending_ratio])
-  const listLimit = overview?.list_limit ?? overview?.pending?.length ?? 0
-  const listDisabled = listLimit === 0
+  const limitActive = overview?.limit_active ?? Boolean(overview?.list_limit && overview.list_limit > 0)
   const entries = overview?.pending ?? []
   const itemsPerPage = 10
   const [page, setPage] = useState(1)
@@ -27,7 +26,7 @@ export default function PendingOverviewPanel({ overview, loading, error }: Pendi
 
   useEffect(() => {
     setPage(1)
-  }, [entries.length, listDisabled])
+  }, [entries.length, limitActive])
 
   useEffect(() => {
     if (page > totalPages) {
@@ -37,7 +36,7 @@ export default function PendingOverviewPanel({ overview, loading, error }: Pendi
 
   const startIndex = (page - 1) * itemsPerPage
   const pageItems = entries.slice(startIndex, startIndex + itemsPerPage)
-  const truncated = !listDisabled && (overview?.displayed_pending ?? entries.length) < pendingCount
+  const truncated = limitActive && (overview?.displayed_pending ?? entries.length) < pendingCount
 
   return (
     <section className="pending-overview">
@@ -66,11 +65,15 @@ export default function PendingOverviewPanel({ overview, loading, error }: Pendi
 
       {loading && <div className="pending-placeholder">Live-Status wird geladen…</div>}
 
-      {!loading && !pendingCount && !error && !listDisabled && (
+      {!loading && !pendingCount && !error && (
         <div className="pending-placeholder">Alle aktuellen Nachrichten wurden bereits analysiert.</div>
       )}
 
-      {!loading && pendingCount > 0 && !listDisabled && (
+      {!loading && pendingCount > 0 && entries.length === 0 && (
+        <div className="pending-placeholder">Keine Details verfügbar.</div>
+      )}
+
+      {!loading && pendingCount > 0 && entries.length > 0 && (
         <div className="pending-table-wrapper">
           {truncated && (
             <div className="pending-limit-info">

--- a/frontend/src/components/TagCanvas.tsx
+++ b/frontend/src/components/TagCanvas.tsx
@@ -1,0 +1,84 @@
+import React, { useMemo } from 'react'
+import { TagSuggestion } from '../api'
+
+interface TagCanvasProps {
+  tags: TagSuggestion[]
+  loading: boolean
+  error: string | null
+  onReload: () => Promise<void> | void
+}
+
+const formatDate = (value?: string | null) => {
+  if (!value) return null
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) {
+    return null
+  }
+  return parsed.toLocaleString('de-DE')
+}
+
+export default function TagCanvas({ tags, loading, error, onReload }: TagCanvasProps): JSX.Element {
+  const headline = useMemo(() => {
+    if (loading) {
+      return 'Tags werden geladen…'
+    }
+    if (!tags.length) {
+      return 'Noch keine vorgeschlagenen Tags'
+    }
+    return `${tags.length} Tag-Vorschläge`
+  }, [loading, tags.length])
+
+  return (
+    <section className="tag-canvas" aria-labelledby="tag-canvas-title">
+      <div className="tag-canvas-header">
+        <div>
+          <h2 id="tag-canvas-title">{headline}</h2>
+          <p className="tag-canvas-subline">
+            Tags werden unabhängig von Ordnerentscheidungen vorgeschlagen und können gesammelt bewertet werden.
+          </p>
+        </div>
+        <button type="button" className="ghost" onClick={onReload} disabled={loading}>
+          {loading ? 'Aktualisiere…' : 'Tags aktualisieren'}
+        </button>
+      </div>
+
+      {error && <div className="status-banner error">{error}</div>}
+
+      {loading && <div className="placeholder">Bitte warten…</div>}
+
+      {!loading && !tags.length && !error && (
+        <div className="placeholder">Sobald neue Tags erkannt werden, erscheinen sie hier.</div>
+      )}
+
+      {!loading && tags.length > 0 && (
+        <div className="tag-grid">
+          {tags.map(tag => {
+            const lastSeen = formatDate(tag.last_seen)
+            return (
+              <article key={tag.tag} className="tag-card">
+                <header>
+                  <h3>{tag.tag}</h3>
+                  <div className="tag-meta">
+                    <span className="count">{tag.occurrences}× vorgeschlagen</span>
+                    {lastSeen && <span className="last-seen">zuletzt {lastSeen}</span>}
+                  </div>
+                </header>
+                {tag.examples.length > 0 && (
+                  <ul className="tag-examples" aria-label={`Beispiele für ${tag.tag}`}>
+                    {tag.examples.map(example => (
+                      <li key={example.message_uid}>
+                        <strong>{example.subject || '(kein Betreff)'}</strong>
+                        {example.from_addr && <span className="from"> · {example.from_addr}</span>}
+                        {example.folder && <span className="folder"> · {example.folder}</span>}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </article>
+            )
+          })}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/frontend/src/store/useTagSuggestions.ts
+++ b/frontend/src/store/useTagSuggestions.ts
@@ -1,0 +1,38 @@
+import { useCallback, useEffect, useState } from 'react'
+import { TagSuggestion, getTagSuggestions } from '../api'
+import { recordDevEvent } from '../devtools'
+
+export interface TagSuggestionsState {
+  data: TagSuggestion[]
+  loading: boolean
+  error: string | null
+  refresh: () => Promise<void>
+}
+
+export function useTagSuggestions(): TagSuggestionsState {
+  const [data, setData] = useState<TagSuggestion[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchData = useCallback(async () => {
+    setLoading(true)
+    try {
+      const tags = await getTagSuggestions()
+      setData(tags)
+      setError(null)
+      recordDevEvent({ type: 'ai', label: 'Tag-Vorschläge', payload: tags })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Tag-Vorschläge konnten nicht geladen werden.'
+      setError(message)
+      recordDevEvent({ type: 'error', label: 'Tag-Vorschläge fehlgeschlagen', payload: message })
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void fetchData()
+  }, [fetchData])
+
+  return { data, loading, error, refresh: fetchData }
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -202,7 +202,8 @@ button.link {
 
 .folder-panel,
 .suggestions,
-.pending-overview {
+.pending-overview,
+.tag-canvas {
   background: rgba(255, 255, 255, 0.8);
   border-radius: 20px;
   padding: 20px 24px;
@@ -211,7 +212,8 @@ button.link {
 
 .folder-panel h2,
 .suggestions h2,
-.pending-overview h2 {
+.pending-overview h2,
+.tag-canvas h2 {
   margin-top: 0;
 }
 
@@ -457,6 +459,89 @@ button.link {
     color: #475569;
     margin-right: 12px;
   }
+}
+
+.tag-canvas {
+  margin-top: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.tag-canvas-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.tag-canvas-subline {
+  margin: 4px 0 0;
+  color: #52606d;
+  font-size: 14px;
+  max-width: 640px;
+}
+
+.tag-grid {
+  display: grid;
+  gap: 16px;
+}
+
+@media (min-width: 720px) {
+  .tag-grid {
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  }
+}
+
+.tag-card {
+  background: #f8fafc;
+  border-radius: 16px;
+  padding: 16px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.tag-card h3 {
+  margin: 0;
+  font-size: 18px;
+  color: #111827;
+}
+
+.tag-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  font-size: 12px;
+  color: #475569;
+}
+
+.tag-meta .count {
+  font-weight: 600;
+  color: #1d4ed8;
+}
+
+.tag-examples {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.tag-examples li {
+  font-size: 13px;
+  color: #1f2937;
+  line-height: 1.4;
+}
+
+.tag-examples .from,
+.tag-examples .folder {
+  color: #64748b;
+  font-weight: 500;
 }
 
 .suggestions-header {


### PR DESCRIPTION
## Summary
- ensure the pending overview always returns entries even when the list limit is disabled and expose that state to the client
- refresh folder proposal heuristics so AI suggestions group mails under broader parent categories
- add aggregated tag suggestion APIs and render a dedicated tag canvas in the frontend with refreshed styles

## Testing
- python -m compileall backend
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e194f51fc883289aa742868118c538