### PR TITLE
Align classifier context window with Ollama models

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,12 @@ MIN_MATCH_SCORE=60
 - `EMBED_PROMPT_MAX_CHARS` limitiert die Länge des Prompts, um Speicherbedarf und Antwortzeiten
   zu kontrollieren.
 - Standardmäßig nutzt der JSON-Klassifikator eine niedrige Temperatur (`CLASSIFIER_TEMPERATURE=0.1`), ein begrenztes Sampling
-  (`CLASSIFIER_TOP_P=0.4`) sowie fixe Grenzen für Kontext (`CLASSIFIER_NUM_CTX=4096`) und Antwortlänge (`CLASSIFIER_NUM_PREDICT=512`).
-  Damit entstehen reproduzierbare, konsistente Ordnerpfade – über Umgebungsvariablen kannst du die Werte feinjustieren.
+  (`CLASSIFIER_TOP_P=0.4`) sowie die von Ollama gemeldete Kontextgrenze (`CLASSIFIER_NUM_CTX_MATCH_MODEL=true`).
+  `CLASSIFIER_NUM_CTX` dient als optionaler Cap und reduziert bei Bedarf das vom Modell angebotene Fenster.
+  Mit `CLASSIFIER_CONTEXT_RESERVE_TOKENS` steuerst du, wie viele Tokens für System- und Kataloginformationen reserviert werden,
+  während `CLASSIFIER_NUM_PREDICT=512` weiterhin die Antwortlänge begrenzt.
+  So entstehen reproduzierbare, konsistente Ordnerpfade ohne die vorherige Trunkierungswarnung – über Umgebungsvariablen kannst
+  du die Werte weiterhin feinjustieren.
 - Verbindungsfehler (`httpx.ConnectError` oder Logeintrag `Ollama Embedding fehlgeschlagen`) deuten
   auf einen nicht erreichbaren Ollama-Host hin. Stelle sicher, dass `OLLAMA_HOST` auf `http://ollama:11434`
   zeigt, wenn alle Dienste via Docker Compose laufen. Bei lokal gestarteten Komponenten außerhalb

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -22,6 +22,8 @@ class Settings(BaseSettings):
     CLASSIFIER_TOP_P: float = 0.4
     CLASSIFIER_NUM_PREDICT: int = 512
     CLASSIFIER_NUM_CTX: int = 4096
+    CLASSIFIER_NUM_CTX_MATCH_MODEL: bool = True
+    CLASSIFIER_CONTEXT_RESERVE_TOKENS: int = 1200
     EMBED_MODEL: str = "nomic-embed-text"
     EMBED_PROMPT_HINT: str = (
         "Berücksichtige Absender-Domains, Kundennummern und Bestellbezüge, "


### PR DESCRIPTION
## Summary
- fetch Ollama model metadata to resolve and cache context window information
- adapt the classifier prompt builder to respect the detected window, trim inputs, and scale catalog excerpts
- document the new context-handling settings so deployments can align limits with their Ollama model

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68e25b060db48328b00df37e676341c5