### PR TITLE
Prevent worker autostart unless explicitly enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ MIN_MATCH_SCORE=60
 - Beim Start prüfen Backend und Worker automatisch, ob die in `CLASSIFIER_MODEL` und `EMBED_MODEL`
   konfigurierten Modelle vorhanden sind. Fehlende Modelle werden über die Ollama-API nachgeladen und
   Probleme im Frontend angezeigt.
+- Der Worker verbleibt standardmäßig im Idle-Modus. Setze `IMAP_WORKER_AUTOSTART=1`, falls die
+  kontinuierliche Analyse weiterhin automatisch beim Start laufen soll – ansonsten steuerst du sowohl
+  Einmal- als auch Daueranalyse ausschließlich über das Dashboard.
 - Über `EMBED_PROMPT_HINT` kannst du zusätzliche Instruktionen (z. B. Projektnamen, Prioritäten)
   setzen, ohne den Code anzupassen. Sowohl Embedding- als auch Klassifikationsprompt greifen auf den Hinweis zu.
 - `EMBED_PROMPT_MAX_CHARS` limitiert die Länge des Prompts, um Speicherbedarf und Antwortzeiten


### PR DESCRIPTION
## Summary
- keep the IMAP worker idle unless IMAP_WORKER_AUTOSTART is explicitly enabled so the scan no longer runs immediately on startup
- add an idle loop fallback and reuse the existing poll interval to avoid busy waiting when the worker is disabled
- document the new IMAP_WORKER_AUTOSTART toggle in the README so deployments know how to restore the legacy behaviour

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68e445f43f808328b50a30d621c1d63d