### PR TITLE
Improve dashboard layout and catalog import behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ MIN_MATCH_SCORE=60
 - Beim Start prüfen Backend und Worker automatisch, ob die in `CLASSIFIER_MODEL` und `EMBED_MODEL`
   konfigurierten Modelle vorhanden sind. Fehlende Modelle werden über die Ollama-API nachgeladen und
   Probleme im Frontend angezeigt.
+- Der Worker verbleibt standardmäßig im Idle-Modus. Setze `IMAP_WORKER_AUTOSTART=1`, falls die
+  kontinuierliche Analyse weiterhin automatisch beim Start laufen soll – ansonsten steuerst du sowohl
+  Einmal- als auch Daueranalyse ausschließlich über das Dashboard.
 - Über `EMBED_PROMPT_HINT` kannst du zusätzliche Instruktionen (z. B. Projektnamen, Prioritäten)
   setzen, ohne den Code anzupassen. Sowohl Embedding- als auch Klassifikationsprompt greifen auf den Hinweis zu.
 - `EMBED_PROMPT_MAX_CHARS` limitiert die Länge des Prompts, um Speicherbedarf und Antwortzeiten
@@ -102,10 +105,10 @@ MIN_MATCH_SCORE=60
 - Der `/api/config`-Endpunkt liefert die komplette Katalogkonfiguration (`folder_templates`, `tag_slots`, `context_tags`),
   sodass auch externe Tools auf die Vorgaben zugreifen können. Änderungen an `llm_config.json` werden beim nächsten Request
   automatisch berücksichtigt.
-- Für interaktive Anpassungen stellt das Frontend eine Editor-Seite unter `#/catalog` bereit. Dort lassen sich Bereiche,
+- Für interaktive Anpassungen stellt das Frontend einen Editor im Einstellungs-Tab „Katalog“ bereit. Dort lassen sich Bereiche,
   Unterordner, Kontext-Tags sowie Tag-Slots (inklusive Aliase) grafisch pflegen und direkt speichern.
 - Das Backend stellt die Rohdaten zusätzlich über `GET /api/catalog` bereit und akzeptiert Aktualisierungen per `PUT /api/catalog`.
-- Über zusätzliche Buttons lassen sich IMAP-Ordnerstrukturen direkt in den Katalog übernehmen (`POST /api/catalog/import-mailbox`) oder der gepflegte Katalog spiegelbildlich im Postfach anlegen (`POST /api/catalog/export-mailbox`). Beide Aktionen sind in der Katalogansicht und im Einstellungs-Tab „Katalog“ verfügbar.
+- Über zusätzliche Buttons lassen sich IMAP-Ordnerstrukturen direkt in den Katalog übernehmen (`POST /api/catalog/import-mailbox`) oder der gepflegte Katalog spiegelbildlich im Postfach anlegen (`POST /api/catalog/export-mailbox`). Beim Import können Standard-IMAP-Ordner wie „INBOX“, „Sent“ oder „Trash“ über eine Ausschlussliste ignoriert werden.
 
 ### Schutz- und Monitoring-Einstellungen
 
@@ -122,7 +125,7 @@ MIN_MATCH_SCORE=60
 
 ### Keyword-Filter & Direktzuordnung
 
-- `backend/keyword_filters.json` definiert Regeln, die E-Mails noch vor der KI-Analyse verschieben. Jede Regel besitzt `name`, `enabled`, `target_folder`, optionale `tags`, eine `match`-Sektion (`mode` = `all` oder `any`, `fields` = `subject`/`sender`/`body`, `terms`) sowie eine optionale `date`-Spanne (`after`/`before` im Format `YYYY-MM-DD`).
+- `backend/keyword_filters.json` definiert Regeln, die E-Mails noch vor der KI-Analyse verschieben. Jede Regel besitzt `name`, `enabled`, `target_folder`, optionale `tags`, eine `match`-Sektion (`mode` = `all` oder `any`, `fields` = `subject`/`sender`/`body`, `terms`) sowie eine optionale `date`-Spanne (`after`/`before` im Format `YYYY-MM-DD`). Über `include_future` lässt sich zusätzlich festlegen, dass Datumsangaben im Mailtext berücksichtigt werden, auch wenn sie nach dem Empfangsdatum liegen (z. B. Event-Termine).
 - Der Editor im Tab „Automatisierung“ stellt dafür Vorlagen für Technik-, Mode- und Lebensmittel-Newsletter, Bestellungen und Rechnungen, Konzert- & Eventtickets sowie Kalendereinladungen bereit. Die Vorlagen befüllen passende Tags und Keywords, Zielordner und Beschreibungen lassen sich anschließend anpassen.
 - Trifft eine Regel zu, legt der Worker fehlende Ordner automatisch an, verschiebt die Nachricht sofort, setzt definierte Tags und protokolliert das Ergebnis als `FilterHit`.
 - Über `GET /api/filters` und `PUT /api/filters` bearbeitest du die Regeln programmatisch. Das Frontend bündelt die Pflege im Tab „Automatisierung“ der Einstellungsseite (`#/settings`) und visualisiert Treffer in einer Automationskachel auf dem Dashboard.
@@ -203,7 +206,7 @@ Die Keyword-Analyse entscheidet zunächst, ob eine Nachricht anhand definierter 
 | `POST`  | `/api/scan/start`   | Startet den kontinuierlichen Scan für die übergebenen Ordner (oder die gespeicherte Auswahl) |
 | `POST`  | `/api/scan/stop`    | Stoppt den laufenden Scan-Controller |
 | `GET`   | `/api/catalog`      | Gibt den aktuellen Ordner- und Tag-Katalog (inkl. Hierarchie) zurück |
-| `POST`  | `/api/catalog/import-mailbox` | Übernimmt die IMAP-Ordnerstruktur als neue Katalogdefinition |
+| `POST`  | `/api/catalog/import-mailbox` | Übernimmt die IMAP-Ordnerstruktur als neue Katalogdefinition (`exclude_defaults` filtert Standardordner) |
 | `POST`  | `/api/catalog/export-mailbox` | Erstellt alle Katalogordner im Postfach (inkl. Zwischenpfade) |
 | `PUT`   | `/api/catalog`      | Persistiert einen aktualisierten Katalog (Ordner & Tag-Slots) |
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { Navigate, Route, Routes } from 'react-router-dom'
 import DashboardPage from './pages/DashboardPage'
-import CatalogEditorPage from './pages/CatalogEditorPage'
 import SettingsPage from './pages/SettingsPage'
 
 export default function App(): JSX.Element {
@@ -9,7 +8,6 @@ export default function App(): JSX.Element {
     <Routes>
       <Route path="/" element={<DashboardPage />} />
       <Route path="/settings" element={<SettingsPage />} />
-      <Route path="/catalog" element={<CatalogEditorPage />} />
       <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>
   )

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -150,6 +150,7 @@ export interface KeywordFilterMatchConfig {
 export interface KeywordFilterDateConfig {
   after?: string | null
   before?: string | null
+  include_future?: boolean
 }
 
 export interface KeywordFilterRuleConfig {
@@ -387,8 +388,18 @@ export async function updateCatalogDefinition(payload: CatalogDefinition): Promi
   })
 }
 
-export async function importCatalogFromMailbox(): Promise<CatalogSyncResponse> {
-  return request<CatalogSyncResponse>('/api/catalog/import-mailbox', { method: 'POST' })
+export interface CatalogImportOptions {
+  excludeDefaults?: string[]
+}
+
+export async function importCatalogFromMailbox(options?: CatalogImportOptions): Promise<CatalogSyncResponse> {
+  const payload = {
+    exclude_defaults: options?.excludeDefaults?.filter(value => value.trim().length > 0) ?? [],
+  }
+  return request<CatalogSyncResponse>('/api/catalog/import-mailbox', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  })
 }
 
 export async function exportCatalogToMailbox(): Promise<CatalogSyncResponse> {

--- a/frontend/src/components/FolderSelectionPanel.tsx
+++ b/frontend/src/components/FolderSelectionPanel.tsx
@@ -55,14 +55,15 @@ const buildFolderTree = (folders: string[]): FolderTreeNode[] => {
   cleaned.sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }))
 
   for (const path of cleaned) {
-    const segments = path.split('/').filter(segment => segment.trim().length > 0)
+    const delimiter = path.includes('/') ? '/' : path.includes('.') ? '.' : '/'
+    const segments = path.split(delimiter).filter(segment => segment.trim().length > 0)
     if (!segments.length) {
       continue
     }
     let current = root
     let currentPath = ''
     for (const segment of segments) {
-      currentPath = currentPath ? `${currentPath}/${segment}` : segment
+      currentPath = currentPath ? `${currentPath}${delimiter}${segment}` : segment
       const node = ensureChild(current, segment, currentPath)
       current = node.map
     }

--- a/frontend/src/components/PendingOverviewPanel.tsx
+++ b/frontend/src/components/PendingOverviewPanel.tsx
@@ -19,6 +19,7 @@ export default function PendingOverviewPanel({ overview, loading, error }: Pendi
   const processedCount = overview?.processed_count ?? 0
   const ratioText = useMemo(() => formatPercent(overview?.pending_ratio ?? 0), [overview?.pending_ratio])
   const limitActive = overview?.limit_active ?? Boolean(overview?.list_limit && overview.list_limit > 0)
+  const limitDisabled = !limitActive && (overview?.list_limit ?? null) === 0
   const entries = overview?.pending ?? []
   const itemsPerPage = 10
   const [page, setPage] = useState(1)
@@ -66,11 +67,19 @@ export default function PendingOverviewPanel({ overview, loading, error }: Pendi
       {loading && <div className="pending-placeholder">Live-Status wird geladen…</div>}
 
       {!loading && !pendingCount && !error && (
-        <div className="pending-placeholder">Alle aktuellen Nachrichten wurden bereits analysiert.</div>
+        <div className="pending-placeholder">
+          {limitDisabled
+            ? 'Detailansicht deaktiviert (PENDING_LIST_LIMIT=0). Zähler bleiben aktiv.'
+            : 'Keine offenen Nachrichten gefunden.'}
+        </div>
       )}
 
       {!loading && pendingCount > 0 && entries.length === 0 && (
-        <div className="pending-placeholder">Keine Details verfügbar.</div>
+        <div className="pending-placeholder">
+          {limitDisabled
+            ? 'Die Liste der offenen Nachrichten ist deaktiviert. Prüfe die Zähler, um den Umfang einzuschätzen.'
+            : 'Keine Details verfügbar.'}
+        </div>
       )}
 
       {!loading && pendingCount > 0 && entries.length > 0 && (

--- a/frontend/src/pages/CatalogEditorPage.tsx
+++ b/frontend/src/pages/CatalogEditorPage.tsx
@@ -1,6 +1,0 @@
-import React from 'react'
-import CatalogEditor from '../components/CatalogEditor'
-
-export default function CatalogEditorPage(): JSX.Element {
-  return <CatalogEditor />
-}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -271,10 +271,66 @@ export default function DashboardPage(): JSX.Element {
           <NavLink to="/settings" className={({ isActive }) => `nav-link${isActive ? ' active' : ''}`}>
             Einstellungen
           </NavLink>
-          <NavLink to="/catalog" className={({ isActive }) => `nav-link${isActive ? ' active' : ''}`}>
-            Katalog
-          </NavLink>
         </nav>
+        <div className="analysis-toolbar">
+          <div className="analysis-status">
+            <span className={`status-dot ${scanSummary.active ? 'active' : 'idle'}`} aria-hidden="true" />
+            <div>
+              <span className="label">Analyse</span>
+              <strong>{scanSummary.statusLabel}</strong>
+            </div>
+          </div>
+          <dl className="analysis-meta">
+            <div>
+              <dt>Ordner</dt>
+              <dd>{scanSummary.folderLabel}</dd>
+            </div>
+            <div>
+              <dt>Intervall</dt>
+              <dd>{scanSummary.pollInterval ? `alle ${Math.round(scanSummary.pollInterval)} s` : '–'}</dd>
+            </div>
+            <div>
+              <dt>Letzter Abschluss</dt>
+              <dd>{scanSummary.lastFinished ?? '–'}</dd>
+            </div>
+            <div>
+              <dt>Ergebnis</dt>
+              <dd>{scanSummary.resultLabel ?? '–'}</dd>
+            </div>
+          </dl>
+          <div className="analysis-actions">
+            <button
+              type="button"
+              className="ghost"
+              onClick={handleRescan}
+              disabled={rescanBusy || scanBusy || scanSummary.active}
+            >
+              {rescanBusy ? 'Analysiere…' : 'Einmalige Analyse'}
+            </button>
+            <button
+              type="button"
+              className="primary"
+              onClick={handleStartScan}
+              disabled={scanBusy || scanSummary.active}
+            >
+              {scanBusy && !scanSummary.active ? 'Starte Analyse…' : 'Analyse starten'}
+            </button>
+            <button
+              type="button"
+              className="ghost"
+              onClick={handleStopScan}
+              disabled={scanBusy || !scanSummary.active}
+            >
+              {scanBusy && scanSummary.active ? 'Stoppe Analyse…' : 'Analyse stoppen'}
+            </button>
+          </div>
+        </div>
+        {(scanSummary.lastStarted || scanSummary.error) && (
+          <div className="analysis-toolbar-meta">
+            {scanSummary.lastStarted && <span>Zuletzt gestartet: {scanSummary.lastStarted}</span>}
+            {scanSummary.error && <span className="analysis-error">Letzter Fehler: {scanSummary.error}</span>}
+          </div>
+        )}
       </header>
 
       {status && (
@@ -319,72 +375,6 @@ export default function DashboardPage(): JSX.Element {
           )}
         </aside>
         <main className="app-main">
-          <section className={`scan-status-card ${scanSummary.active ? 'active' : 'idle'}`}>
-            <div className="scan-status-header">
-              <div>
-                <h2>Analyse-Status</h2>
-                <p className="scan-status-subline">
-                  {scanSummary.active
-                    ? 'Die automatische Analyse läuft kontinuierlich. Einmalanalysen sind währenddessen deaktiviert.'
-                    : 'Starte bei Bedarf die Daueranalyse oder führe eine Einmalanalyse für eine sofortige Auswertung aus.'}
-                </p>
-              </div>
-              <div className="scan-actions">
-                <button
-                  type="button"
-                  className="ghost"
-                  onClick={handleRescan}
-                  disabled={rescanBusy || scanBusy || scanSummary.active}
-                >
-                  {rescanBusy ? 'Analysiere…' : 'Einmalige Analyse'}
-                </button>
-                <button
-                  type="button"
-                  className="primary"
-                  onClick={handleStartScan}
-                  disabled={scanBusy || scanSummary.active}
-                >
-                  {scanBusy && !scanSummary.active ? 'Starte Analyse…' : 'Analyse starten'}
-                </button>
-                <button
-                  type="button"
-                  className="ghost"
-                  onClick={handleStopScan}
-                  disabled={scanBusy || !scanSummary.active}
-                >
-                  {scanBusy && scanSummary.active ? 'Stoppe Analyse…' : 'Analyse stoppen'}
-                </button>
-              </div>
-            </div>
-            <div className="scan-status-body">
-              <div className="scan-stat">
-                <span className="label">Status</span>
-                <strong>{scanSummary.statusLabel}</strong>
-              </div>
-              <div className="scan-stat">
-                <span className="label">Ordner</span>
-                <strong>{scanSummary.folderLabel}</strong>
-              </div>
-              <div className="scan-stat">
-                <span className="label">Intervall</span>
-                <strong>
-                  {scanSummary.pollInterval ? `alle ${Math.round(scanSummary.pollInterval)} s` : '–'}
-                </strong>
-              </div>
-              <div className="scan-stat">
-                <span className="label">Letzter Lauf</span>
-                <strong>{scanSummary.lastFinished ?? '–'}</strong>
-              </div>
-              <div className="scan-stat">
-                <span className="label">Ergebnis</span>
-                <strong>{scanSummary.resultLabel ?? '–'}</strong>
-              </div>
-            </div>
-            {scanSummary.lastStarted && (
-              <div className="scan-status-meta">Zuletzt gestartet: {scanSummary.lastStarted}</div>
-            )}
-            {scanSummary.error && <div className="scan-status-error">Letzter Fehler: {scanSummary.error}</div>}
-          </section>
           <AutomationSummaryCard
             activity={filterActivity}
             loading={filterActivityLoading}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -10,7 +10,7 @@
 
 body {
   margin: 0;
-  background: radial-gradient(circle at top left, #fdfefe, #eef3fb 45%, #e3ebf8 100%);
+  background: linear-gradient(180deg, #f7f9fc 0%, #eef1f8 100%);
   min-height: 100vh;
 }
 
@@ -21,12 +21,12 @@ input {
 }
 
 .app-shell {
-  max-width: 1240px;
-  margin: 32px auto;
-  padding: 0 24px 48px;
+  max-width: 1180px;
+  margin: 24px auto 48px;
+  padding: 0 24px 40px;
   display: flex;
   flex-direction: column;
-  gap: 28px;
+  gap: 24px;
 }
 
 .app-header {
@@ -49,6 +49,117 @@ input {
   flex-wrap: wrap;
 }
 
+.analysis-toolbar {
+  display: flex;
+  gap: 24px;
+  align-items: center;
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 16px;
+  padding: 14px 20px;
+  box-shadow: 0 14px 32px rgba(15, 23, 42, 0.08);
+}
+
+.analysis-status {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.status-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  background: #94a3b8;
+  box-shadow: inset 0 0 0 2px rgba(148, 163, 184, 0.2);
+}
+
+.status-dot.active {
+  background: #22c55e;
+  box-shadow: inset 0 0 0 2px rgba(34, 197, 94, 0.25);
+}
+
+.analysis-toolbar .label {
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #64748b;
+}
+
+.analysis-toolbar strong {
+  font-size: 16px;
+  color: #0f172a;
+}
+
+.analysis-meta {
+  display: grid;
+  grid-auto-flow: column;
+  gap: 20px;
+  margin: 0;
+}
+
+.analysis-meta div {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 130px;
+}
+
+.analysis-meta dt {
+  margin: 0;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #64748b;
+}
+
+.analysis-meta dd {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.analysis-actions {
+  margin-left: auto;
+  display: flex;
+  gap: 12px;
+}
+
+.analysis-toolbar-meta {
+  margin-top: 8px;
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  font-size: 13px;
+  color: #475569;
+}
+
+.analysis-toolbar-meta .analysis-error {
+  color: #b91c1c;
+  font-weight: 600;
+}
+
+@media (max-width: 900px) {
+  .analysis-toolbar {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 16px;
+  }
+
+  .analysis-meta {
+    grid-auto-flow: row;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    width: 100%;
+  }
+
+  .analysis-actions {
+    margin-left: 0;
+    width: 100%;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
+}
+
 .app-layout {
   display: flex;
   gap: 24px;
@@ -56,7 +167,7 @@ input {
 }
 
 .app-sidebar {
-  flex: 0 0 320px;
+  flex: 0 0 260px;
   position: sticky;
   top: 24px;
   align-self: flex-start;
@@ -116,8 +227,8 @@ input {
   margin-top: 16px;
   padding: 16px 18px;
   border-radius: 16px;
-  background: rgba(255, 255, 255, 0.9);
-  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.12);
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 12px 26px rgba(15, 23, 42, 0.1);
   display: flex;
   flex-direction: column;
   gap: 10px;
@@ -1352,6 +1463,84 @@ a.nav-link.active {
   gap: 16px;
 }
 
+.catalog-sync {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 24px;
+  align-items: flex-start;
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 20px;
+  padding: 20px 24px;
+  box-shadow: 0 14px 32px rgba(15, 23, 42, 0.1);
+}
+
+.catalog-sync-info {
+  flex: 1 1 320px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  color: #1f2937;
+}
+
+.catalog-sync-warning {
+  margin: 0;
+  font-size: 13px;
+  color: #b45309;
+  background: rgba(251, 191, 36, 0.18);
+  padding: 6px 10px;
+  border-radius: 10px;
+  display: inline-flex;
+  max-width: 480px;
+}
+
+.catalog-sync-controls {
+  flex: 1 1 320px;
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+
+.catalog-sync-buttons {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.catalog-sync-defaults {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 13px;
+  color: #475569;
+}
+
+.catalog-default-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.catalog-default-grid label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: #f8fafc;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  font-size: 12px;
+}
+
+.catalog-default-grid input {
+  margin: 0;
+}
+
+.catalog-default-grid label.disabled {
+  opacity: 0.6;
+}
+
 .catalog-body {
   display: flex;
   flex-direction: column;
@@ -1824,6 +2013,66 @@ button.link.danger:hover {
   flex-wrap: wrap;
   gap: 12px;
   justify-content: flex-end;
+}
+
+.template-menu-wrapper {
+  position: relative;
+}
+
+.template-menu {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  min-width: 280px;
+  background: #ffffff;
+  border-radius: 12px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: 0 18px 32px rgba(15, 23, 42, 0.15);
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  z-index: 40;
+}
+
+.template-menu-item {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  border: none;
+  background: transparent;
+  padding: 8px 10px;
+  border-radius: 10px;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.2s ease;
+  width: 100%;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.template-menu-item span {
+  font-size: 12px;
+  font-weight: 400;
+  color: #64748b;
+}
+
+.template-menu-item:hover {
+  background: rgba(59, 130, 246, 0.12);
+  color: #1d4ed8;
+}
+
+.template-menu-divider {
+  height: 1px;
+  background: rgba(15, 23, 42, 0.08);
+  margin: 4px 0;
+}
+
+.template-menu-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }
 
 .automation-editor {


### PR DESCRIPTION
## Summary
- redesign the dashboard header into a horizontal analysis toolbar and modernize the overall layout while narrowing the folder sidebar
- add an inline rule template menu with future-date matching support in automation settings and update pending mail messaging for unlimited lists
- enhance catalog import/export controls with default-folder exclusions, confirmations, and refreshed styling, documenting the new options

## Testing
- python -m compileall backend
- npm run build --prefix frontend

------
https://chatgpt.com/codex/tasks/task_e_68e445f43f808328b50a30d621c1d63d