### PR TITLE
Add analysis modules and improve dashboard layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,11 @@ MIN_MATCH_SCORE=60
 
 - `IMAP_PROTECTED_TAG` kennzeichnet Nachrichten, die vom Worker übersprungen werden sollen (z. B. manuell markierte Threads).
 - `IMAP_PROCESSED_TAG` wird nach erfolgreicher Verarbeitung automatisch gesetzt und verhindert erneute Scans.
-- Der Tab „Betrieb“ in den Einstellungen erlaubt das Bearbeiten von Verarbeitungsmodus, Ollama-Modell und IMAP-Tags; das Dashboard zeigt den aktuellen Modus nur noch an.
+- Der Tab „Betrieb“ in den Einstellungen bündelt die Auswahl von Analyse-Modul, Verarbeitungsmodus, Ollama-Modell und IMAP-Tags; das Dashboard zeigt den gewählten Modus weiterhin an.
+- Die Module steuern, welche Informationen sichtbar sind:
+  - **Statisch** setzt ausschließlich auf Keyword-Regeln. KI-Kontexte (Scores, Tag-Vorschläge, Kategorien) werden im Dashboard ausgeblendet – ideal, wenn kein LLM verfügbar ist.
+  - **Hybrid** nutzt zuerst die statischen Regeln und analysiert verbleibende Nachrichten per LLM. Alle Kontextinformationen bleiben sichtbar.
+  - **LLM Pure** ignoriert die Regeln und verarbeitet jede Mail per LLM. Die Regel-Übersicht im Dashboard blendet sich dabei automatisch aus.
 - `INIT_RUN` setzt beim nächsten Start die Datenbank zurück (Tabellen werden geleert, SQLite-Dateien neu angelegt).
 - `PENDING_LIST_LIMIT` bestimmt die maximale Anzahl angezeigter Einträge im Pending-Dashboard (0 deaktiviert die Begrenzung).
 - `DEV_MODE` aktiviert zusätzliche Debug-Ausgaben im Backend sowie das Dev-Panel im Frontend.

--- a/backend/database.py
+++ b/backend/database.py
@@ -218,6 +218,21 @@ def get_classifier_model() -> Optional[str]:
     return normalized or None
 
 
+def set_analysis_module(module: str) -> None:
+    normalized = str(module or "").strip().upper()
+    if not normalized:
+        raise ValueError("analysis module must not be empty")
+    _set_config_value("ANALYSIS_MODULE", normalized)
+
+
+def get_analysis_module_override() -> Optional[str]:
+    value = _get_config_value("ANALYSIS_MODULE")
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().upper()
+    return normalized or None
+
+
 def set_mailbox_tags(protected: str | None, processed: str | None, ai_prefix: str | None) -> None:
     payload = json.dumps(
         {

--- a/backend/runtime_settings.py
+++ b/backend/runtime_settings.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 from typing import Tuple
 
 from settings import S
-from database import get_classifier_model, get_mailbox_tags, get_mode_override
+from database import (
+    get_analysis_module_override,
+    get_classifier_model,
+    get_mailbox_tags,
+    get_mode_override,
+)
 
 
 def resolve_move_mode() -> str:
@@ -34,3 +39,12 @@ def resolve_mailbox_tags() -> Tuple[str | None, str | None, str | None]:
     processed = stored_processed if stored_processed is not None else (S.IMAP_PROCESSED_TAG or None)
     prefix = stored_prefix if stored_prefix is not None else (S.IMAP_AI_TAG_PREFIX or None)
     return protected, processed, prefix
+
+
+def resolve_analysis_module() -> str:
+    """Return the selected analysis module with persisted overrides."""
+
+    override = get_analysis_module_override()
+    if override:
+        return override
+    return S.ANALYSIS_MODULE

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -50,6 +50,8 @@ class Settings(BaseSettings):
 
     DEV_MODE: bool = False
 
+    ANALYSIS_MODULE: str = "HYBRID"
+
     class Config:
         env_file = ".env"
 

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,6 +1,7 @@
 import { recordDevEvent } from './devtools'
 
 export type MoveMode = 'DRY_RUN' | 'CONFIRM' | 'AUTO'
+export type AnalysisModule = 'STATIC' | 'HYBRID' | 'LLM_PURE'
 
 export interface SuggestionScore {
   name: string
@@ -198,6 +199,7 @@ export interface AppConfig {
   dev_mode: boolean
   pending_list_limit: number
   mode: MoveMode
+  analysis_module: AnalysisModule
   classifier_model: string
   protected_tag: string | null
   processed_tag: string | null
@@ -210,6 +212,7 @@ export interface AppConfig {
 
 export interface AppConfigUpdateRequest {
   mode?: MoveMode
+  analysis_module?: AnalysisModule
   classifier_model?: string
   protected_tag?: string | null
   processed_tag?: string | null

--- a/frontend/src/components/SuggestionCard.tsx
+++ b/frontend/src/components/SuggestionCard.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react'
-import { Suggestion, TagSlotConfig, createFolder, decide, decideProposal, moveOne } from '../api'
+import { AnalysisModule, Suggestion, TagSlotConfig, createFolder, decide, decideProposal, moveOne } from '../api'
 
 interface Props {
   suggestion: Suggestion
@@ -7,6 +7,7 @@ interface Props {
   tagSlots?: TagSlotConfig[]
   availableFolders?: string[]
   onFolderCreated?: (folder: string) => Promise<void> | void
+  analysisModule: AnalysisModule
 }
 
 type BusyState = 'simulate' | 'accept' | 'reject' | 'proposal-accept' | 'proposal-reject' | null
@@ -37,6 +38,7 @@ export default function SuggestionCard({
   tagSlots,
   availableFolders = [],
   onFolderCreated,
+  analysisModule,
 }: Props): JSX.Element {
   const [target, setTarget] = useState<string>(fallbackTarget(suggestion))
   const [busy, setBusy] = useState<BusyState>(null)
@@ -118,6 +120,7 @@ export default function SuggestionCard({
     return Number.isNaN(parsed.getTime()) ? suggestion.date : parsed.toLocaleString('de-DE')
   }, [suggestion.date])
 
+  const showAiContext = analysisModule !== 'STATIC'
   const topScore = suggestion.ranked?.[0]?.score ?? null
   const topReason = suggestion.ranked?.[0]?.reason ?? null
   const category = suggestion.category ?? null
@@ -269,7 +272,7 @@ export default function SuggestionCard({
         {suggestion.from_addr && <div className="meta">{suggestion.from_addr}</div>}
         {created && <div className="meta">Empfangen: {created}</div>}
         {suggestion.src_folder && <div className="badge">Quelle: {suggestion.src_folder}</div>}
-        {categoryLabel && (
+        {showAiContext && categoryLabel && (
           <div className="category-info">
             <span className="category-label">Überbegriff:</span>
             <strong>{categoryLabel}</strong>
@@ -286,14 +289,14 @@ export default function SuggestionCard({
         <div className={`feedback ${statusInfo.tone === 'error' ? 'error' : 'info'}`}>{statusInfo.detail}</div>
       )}
 
-      {topScore !== null && (
+      {showAiContext && topScore !== null && (
         <div className="score">
           Empfohlener Ordner: {suggestion.ranked?.[0]?.name ?? '–'} (Score {formatScore(topScore)})
           {topReason && <span className="score-reason"> – {topReason}</span>}
         </div>
       )}
 
-      {suggestion.ranked && suggestion.ranked.length > 1 && (
+      {showAiContext && suggestion.ranked && suggestion.ranked.length > 1 && (
         <div className="alternatives" aria-label="Weitere Vorschläge">
           {suggestion.ranked.slice(1).map(item => (
             <span key={item.name} className="alt-badge">
@@ -304,7 +307,7 @@ export default function SuggestionCard({
         </div>
       )}
 
-      {hasTagField && (
+      {showAiContext && hasTagField && (
         <div className="tag-list" aria-label="Erkannte Tag-Kategorien">
           {tagCategories.map(item => (
             <span key={item.label} className={`tag-badge${item.value ? '' : ' empty'}`}>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -21,9 +21,9 @@ input {
 }
 
 .app-shell {
-  max-width: 1180px;
+  max-width: 1320px;
   margin: 24px auto 48px;
-  padding: 0 24px 40px;
+  padding: 0 32px 40px;
   display: flex;
   flex-direction: column;
   gap: 24px;
@@ -57,10 +57,10 @@ input {
 }
 
 .analysis-canvas {
-  flex: 1 1 420px;
+  flex: 1 1 460px;
   background: rgba(255, 255, 255, 0.92);
   border-radius: 20px;
-  padding: 18px 24px;
+  padding: 22px 28px;
   box-shadow: 0 24px 60px rgba(15, 23, 42, 0.14);
   display: flex;
   flex-direction: column;
@@ -70,20 +70,46 @@ input {
 .analysis-status {
   display: flex;
   align-items: center;
-  gap: 14px;
+  gap: 16px;
 }
 
-.status-dot {
-  width: 12px;
-  height: 12px;
+.status-indicator {
+  width: 16px;
+  height: 16px;
   border-radius: 999px;
-  background: #94a3b8;
-  box-shadow: inset 0 0 0 2px rgba(148, 163, 184, 0.2);
+  background: linear-gradient(135deg, #94a3b8, #64748b);
+  box-shadow: 0 0 0 3px rgba(148, 163, 184, 0.15);
+  position: relative;
 }
 
-.status-dot.active {
-  background: #22c55e;
-  box-shadow: inset 0 0 0 2px rgba(34, 197, 94, 0.25);
+.status-indicator::after {
+  content: '';
+  position: absolute;
+  inset: 3px;
+  border-radius: inherit;
+  background: rgba(255, 255, 255, 0.35);
+  mix-blend-mode: screen;
+}
+
+.status-indicator.running {
+  background: linear-gradient(135deg, #16a34a, #22c55e);
+  box-shadow: 0 0 0 3px rgba(34, 197, 94, 0.22);
+}
+
+.status-indicator.paused {
+  background: linear-gradient(135deg, #f59e0b, #facc15);
+  box-shadow: 0 0 0 3px rgba(250, 204, 21, 0.25);
+}
+
+.status-indicator.stopped {
+  background: linear-gradient(135deg, #ef4444, #f97316);
+  box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.22);
+}
+
+.analysis-status-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
 }
 
 .analysis-status .label {
@@ -94,7 +120,7 @@ input {
 }
 
 .analysis-status strong {
-  font-size: 16px;
+  font-size: 18px;
   color: #0f172a;
 }
 
@@ -127,20 +153,20 @@ input {
 }
 
 .analysis-actions {
-  display: flex;
-  gap: 12px;
-  flex-wrap: wrap;
-  align-items: flex-start;
-  justify-content: flex-end;
-  padding: 18px 20px;
-  background: rgba(15, 23, 42, 0.03);
+  display: grid;
+  gap: 14px;
+  padding: 22px 24px;
+  background: rgba(15, 23, 42, 0.04);
   border-radius: 20px;
-  flex: 0 0 280px;
+  flex: 0 1 320px;
+  min-width: 280px;
   box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.18);
+  align-content: flex-start;
 }
 
 .analysis-actions button {
-  min-width: 160px;
+  min-width: unset;
+  width: 100%;
 }
 
 .analysis-foot {
@@ -167,7 +193,8 @@ input {
 
   .analysis-actions {
     width: 100%;
-    justify-content: flex-start;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    min-width: 0;
   }
 }
 
@@ -178,7 +205,7 @@ input {
 }
 
 .app-sidebar {
-  flex: 0 0 260px;
+  flex: 0 0 220px;
   position: sticky;
   top: 24px;
   align-self: flex-start;
@@ -232,6 +259,18 @@ input {
   font-weight: 600;
   font-size: 13px;
   border: 1px solid rgba(59, 130, 246, 0.25);
+}
+
+.mode-badge.module {
+  background: rgba(34, 197, 94, 0.18);
+  color: #047857;
+  border-color: rgba(34, 197, 94, 0.3);
+}
+
+.mode-badge.subtle {
+  background: rgba(148, 163, 184, 0.18);
+  color: #334155;
+  border-color: rgba(148, 163, 184, 0.32);
 }
 
 .ollama-status-card {
@@ -2155,28 +2194,40 @@ button.link.danger:hover {
 
 .template-toggle {
   border: none;
-  background: transparent;
+  background: rgba(37, 99, 235, 0.08);
   text-align: left;
-  padding: 0;
+  padding: 12px 16px;
   cursor: pointer;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 6px;
   color: #0f172a;
+  border-radius: 14px;
+  min-width: 240px;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+  align-items: flex-start;
 }
 
 .template-toggle .template-name {
   font-weight: 600;
-  font-size: 15px;
+  font-size: 16px;
+  line-height: 1.3;
 }
 
 .template-toggle .template-folder {
   font-size: 13px;
-  color: #64748b;
+  color: #475569;
 }
 
-.template-toggle:hover .template-name,
-.template-toggle.open .template-name {
+.template-toggle:hover,
+.template-toggle.open {
+  background: rgba(37, 99, 235, 0.16);
+  color: #1d4ed8;
+  box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.25);
+}
+
+.template-toggle:hover .template-folder,
+.template-toggle.open .template-folder {
   color: #1d4ed8;
 }
 
@@ -2494,6 +2545,57 @@ button.link.danger:hover {
 .mode-select.large select {
   padding: 12px 14px;
   font-size: 16px;
+}
+
+.module-description-list {
+  list-style: none;
+  padding: 0;
+  margin: 20px 0 12px;
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.module-description-list li {
+  background: rgba(15, 23, 42, 0.04);
+  border-radius: 14px;
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  border: 1px solid transparent;
+  min-height: 92px;
+}
+
+.module-description-list li.active {
+  border-color: rgba(37, 99, 235, 0.3);
+  box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.25);
+  background: rgba(59, 130, 246, 0.12);
+}
+
+.module-headline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  color: #0f172a;
+  font-size: 14px;
+}
+
+.module-headline .badge {
+  background: rgba(34, 197, 94, 0.18);
+  color: #047857;
+  border-radius: 999px;
+  padding: 2px 8px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.module-description-list span {
+  font-size: 13px;
+  color: #475569;
 }
 
 .mode-description-list {


### PR DESCRIPTION
## Summary
- add configurable analysis modules persisted in the backend and exposed through the config API
- refresh the dashboard layout with a traffic-light status indicator, wider action block, module badges, and module-aware content visibility
- hide AI context details when the static module is active, restyle template toggles, and document the new module behaviour

## Testing
- python -m compileall backend
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e45cf48b2c832891fada5e80e990bb