### PR TITLE
Add developer console for dev mode diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,10 @@ Die FastAPI-Anwendung lädt Konfigurationen aus `.env` über [`backend/settings.
 - `INIT_RUN` setzt beim nächsten Start die Datenbank zurück (Tabellen werden geleert, SQLite-Dateien neu angelegt).
 - `PENDING_LIST_LIMIT` bestimmt die maximale Anzahl angezeigter Einträge im Pending-Dashboard (0 deaktiviert die Begrenzung).
 - `DEV_MODE` aktiviert zusätzliche Debug-Ausgaben im Backend sowie das Dev-Panel im Frontend.
-  Optional kann das Frontend per `VITE_DEV_MODE=true` (in `frontend/.env`) unabhängig vom Backend gestartet werden.
+  Der Modus schaltet außerdem die Developer-Console unter `#/dev` frei: Dort findest du alle laufzeitrelevanten Parameter
+  (Move-Modus, Analyse-Modul, IMAP-Tags, Pending-Limit, Katalog-Zuschnitt), den aktuellen Ollama-Status inklusive Modellauflistung
+  und die aktiven Frontend-Umgebungswerte (`VITE_API_BASE`, `VITE_DEV_MODE`, Build-Typ, Stream-URL). Optional kann das Frontend
+  per `VITE_DEV_MODE=true` (in `frontend/.env`) unabhängig vom Backend gestartet werden.
 - Über `/api/scan/start`, `/api/scan/stop` und `/api/scan/status` steuerst du den kontinuierlichen Analyse-Controller. Das Frontend bietet zusätzlich einen Button „Einmalige Analyse“ (via `/api/rescan`), sodass sich eine sofortige Auswertung ohne Daueranalyse starten lässt. Laufende Einmalanalysen lassen sich über „Analyse stoppen“ abbrechen; das Backend verwirft dabei den aktiven Scanauftrag.
 - Laufende Dauer-Analysen blockieren den Einmal-Modus, bis sie gestoppt sind; parallel bleiben „Analyse starten“ und „Analyse stoppen“ für die kontinuierliche Ausführung verfügbar.
 - Die Ordnerauswahl im Dashboard stellt die überwachten IMAP-Ordner als aufklappbaren Baum dar. Der Filter hebt Treffer farblich hervor und öffnet automatisch die relevanten Äste, sodass komplexe Hierarchien schneller angepasst werden können.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Navigate, Route, Routes } from 'react-router-dom'
 import DashboardPage from './pages/DashboardPage'
+import DevModePage from './pages/DevModePage'
 import SettingsPage from './pages/SettingsPage'
 
 export default function App(): JSX.Element {
@@ -8,6 +9,7 @@ export default function App(): JSX.Element {
     <Routes>
       <Route path="/" element={<DashboardPage />} />
       <Route path="/settings" element={<SettingsPage />} />
+      <Route path="/dev" element={<DevModePage />} />
       <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>
   )

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -299,6 +299,9 @@ const wsProtocol = baseUrl.protocol === 'https:' ? 'wss:' : 'ws:'
 const normalizedPath = baseUrl.pathname.replace(/\/$/, '')
 const STREAM_URL = `${wsProtocol}//${baseUrl.host}${normalizedPath}/ws/stream`
 
+export const API_BASE_URL = BASE
+export const STREAM_WEBSOCKET_URL = STREAM_URL
+
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
   const method = init?.method ?? 'GET'
   const label = `${method} ${path}`

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -20,6 +20,7 @@ import { useSuggestions } from '../store/useSuggestions'
 import { usePendingOverview } from '../store/usePendingOverview'
 import { useAppConfig } from '../store/useAppConfig'
 import { useFilterActivity } from '../store/useFilterActivity'
+import { useDevMode } from '../devtools'
 
 type StatusKind = 'info' | 'success' | 'error'
 
@@ -80,6 +81,7 @@ export default function DashboardPage(): JSX.Element {
   const scanStateRef = useRef({ auto: false, manual: false })
   const analysisModule: AnalysisModule = appConfig?.analysis_module ?? 'HYBRID'
   const moduleLabel = moduleLabels[analysisModule]
+  const devMode = useDevMode()
 
   const loadFolders = useCallback(async () => {
     setFoldersLoading(true)
@@ -438,6 +440,11 @@ export default function DashboardPage(): JSX.Element {
           <NavLink to="/settings" className={({ isActive }) => `nav-link${isActive ? ' active' : ''}`}>
             Einstellungen
           </NavLink>
+          {devMode && (
+            <NavLink to="/dev" className={({ isActive }) => `nav-link${isActive ? ' active' : ''}`}>
+              Dev-Mode
+            </NavLink>
+          )}
         </nav>
         <div className="analysis-top">
           <div className="analysis-canvas">

--- a/frontend/src/pages/DevModePage.tsx
+++ b/frontend/src/pages/DevModePage.tsx
@@ -1,0 +1,227 @@
+import React, { useMemo } from 'react'
+import { NavLink } from 'react-router-dom'
+import DevtoolsPanel from '../components/DevtoolsPanel'
+import { useAppConfig } from '../store/useAppConfig'
+import { useDevMode } from '../devtools'
+import { API_BASE_URL, STREAM_WEBSOCKET_URL } from '../api'
+
+function formatDate(value: string | null | undefined): string {
+  if (!value) {
+    return '–'
+  }
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return value
+  }
+  return `${date.toLocaleDateString()} ${date.toLocaleTimeString()}`
+}
+
+export default function DevModePage(): JSX.Element {
+  const devMode = useDevMode()
+  const { data: appConfig, loading, error, refresh } = useAppConfig()
+
+  const frontendEnv = useMemo(
+    () => [
+      { key: 'Build-Modus', value: import.meta.env.MODE },
+      { key: 'Entwicklungsbuild', value: import.meta.env.DEV ? 'ja' : 'nein' },
+      { key: 'Produktionsbuild', value: import.meta.env.PROD ? 'ja' : 'nein' },
+      { key: 'Vite Base URL', value: import.meta.env.BASE_URL },
+      { key: 'API Basis', value: API_BASE_URL },
+      { key: 'Stream-Endpunkt', value: STREAM_WEBSOCKET_URL },
+      {
+        key: 'VITE_DEV_MODE',
+        value: String(import.meta.env.VITE_DEV_MODE ?? 'nicht gesetzt'),
+      },
+    ],
+    [],
+  )
+
+  return (
+    <div className="app-shell">
+      <header className="app-header">
+        <div className="header-top">
+          <div>
+            <h1>Developer Console</h1>
+            <p className="app-subline">
+              Laufzeitparameter, Systemstatus und API-Aktivitäten im Überblick.
+            </p>
+          </div>
+        </div>
+        <nav className="primary-nav">
+          <NavLink to="/" end className={({ isActive }) => `nav-link${isActive ? ' active' : ''}`}>
+            Dashboard
+          </NavLink>
+          <NavLink to="/settings" className={({ isActive }) => `nav-link${isActive ? ' active' : ''}`}>
+            Einstellungen
+          </NavLink>
+          <NavLink to="/dev" className={({ isActive }) => `nav-link${isActive ? ' active' : ''}`}>
+            Dev-Mode
+          </NavLink>
+        </nav>
+      </header>
+
+      <main className="dev-mode-main">
+        {!devMode && (
+          <div className="status-banner warning" role="alert">
+            <span>Dev-Modus ist nicht aktiv. Aktiviere ihn im Backend oder via Umgebungsvariable.</span>
+          </div>
+        )}
+        {error && (
+          <div className="status-banner error" role="alert">
+            <span>{error}</span>
+            <button type="button" className="link" onClick={() => refresh()}>
+              Erneut laden
+            </button>
+          </div>
+        )}
+        <section className="dev-mode-grid">
+          <article className="dev-card">
+            <header>
+              <h2>Backend-Konfiguration</h2>
+              <span>{loading ? 'lädt…' : 'aktuell'}</span>
+            </header>
+            {appConfig ? (
+              <dl>
+                <div>
+                  <dt>Dev-Modus</dt>
+                  <dd>{appConfig.dev_mode ? 'aktiv' : 'deaktiviert'}</dd>
+                </div>
+                <div>
+                  <dt>Move-Modus</dt>
+                  <dd>{appConfig.mode}</dd>
+                </div>
+                <div>
+                  <dt>Analyse-Modul</dt>
+                  <dd>{appConfig.analysis_module}</dd>
+                </div>
+                <div>
+                  <dt>Classifier-Modell</dt>
+                  <dd>{appConfig.classifier_model}</dd>
+                </div>
+                <div>
+                  <dt>Pending-Limit</dt>
+                  <dd>
+                    {appConfig.pending_list_limit > 0
+                      ? `${appConfig.pending_list_limit} Einträge`
+                      : 'kein Limit'}
+                  </dd>
+                </div>
+                <div>
+                  <dt>Protected-Tag</dt>
+                  <dd>{appConfig.protected_tag ?? '–'}</dd>
+                </div>
+                <div>
+                  <dt>Processed-Tag</dt>
+                  <dd>{appConfig.processed_tag ?? '–'}</dd>
+                </div>
+                <div>
+                  <dt>AI-Tag-Präfix</dt>
+                  <dd>{appConfig.ai_tag_prefix ?? '–'}</dd>
+                </div>
+                <div>
+                  <dt>Templates</dt>
+                  <dd>{appConfig.folder_templates.length} Vorlagen</dd>
+                </div>
+                <div>
+                  <dt>Tag-Slots</dt>
+                  <dd>{appConfig.tag_slots.length} Slots</dd>
+                </div>
+                <div>
+                  <dt>Kontext-Tags</dt>
+                  <dd>{appConfig.context_tags.length} Einträge</dd>
+                </div>
+              </dl>
+            ) : (
+              <p className="muted">Keine Konfiguration geladen.</p>
+            )}
+          </article>
+
+          <article className="dev-card">
+            <header>
+              <h2>Ollama-Status</h2>
+              {appConfig?.ollama?.last_checked && (
+                <span>Stand: {formatDate(appConfig.ollama.last_checked)}</span>
+              )}
+            </header>
+            {appConfig?.ollama ? (
+              <div className="dev-card-block">
+                <dl>
+                  <div>
+                    <dt>Host</dt>
+                    <dd>{appConfig.ollama.host}</dd>
+                  </div>
+                  <div>
+                    <dt>Erreichbar</dt>
+                    <dd>{appConfig.ollama.reachable ? 'ja' : 'nein'}</dd>
+                  </div>
+                  {appConfig.ollama.message && (
+                    <div>
+                      <dt>Meldung</dt>
+                      <dd>{appConfig.ollama.message}</dd>
+                    </div>
+                  )}
+                </dl>
+                <div className="dev-models">
+                  {appConfig.ollama.models.map(model => (
+                    <article key={model.name} className={`dev-model ${model.available ? 'ready' : 'missing'}`}>
+                      <header>
+                        <strong>{model.name}</strong>
+                        <span>{model.purpose}</span>
+                      </header>
+                      <dl>
+                        <div>
+                          <dt>Pull-Status</dt>
+                          <dd>{model.pulled ? 'geladen' : 'nicht geladen'}</dd>
+                        </div>
+                        <div>
+                          <dt>Verfügbar</dt>
+                          <dd>{model.available ? 'ja' : 'nein'}</dd>
+                        </div>
+                        {model.digest && (
+                          <div>
+                            <dt>Digest</dt>
+                            <dd>{model.digest}</dd>
+                          </div>
+                        )}
+                        {typeof model.size === 'number' && (
+                          <div>
+                            <dt>Größe</dt>
+                            <dd>{(model.size / (1024 ** 3)).toFixed(2)} GB</dd>
+                          </div>
+                        )}
+                        {model.message && (
+                          <div>
+                            <dt>Hinweis</dt>
+                            <dd>{model.message}</dd>
+                          </div>
+                        )}
+                      </dl>
+                    </article>
+                  ))}
+                </div>
+              </div>
+            ) : (
+              <p className="muted">Kein Ollama-Status verfügbar.</p>
+            )}
+          </article>
+
+          <article className="dev-card">
+            <header>
+              <h2>Frontend-Umgebung</h2>
+            </header>
+            <dl>
+              {frontendEnv.map(entry => (
+                <div key={entry.key}>
+                  <dt>{entry.key}</dt>
+                  <dd>{entry.value}</dd>
+                </div>
+              ))}
+            </dl>
+          </article>
+        </section>
+      </main>
+
+      <DevtoolsPanel />
+    </div>
+  )
+}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -17,6 +17,7 @@ import DevtoolsPanel from '../components/DevtoolsPanel'
 import RuleEditorForm, { EditableRuleDraft } from '../components/RuleEditorForm'
 import { useAppConfig } from '../store/useAppConfig'
 import { useFilterActivity } from '../store/useFilterActivity'
+import { useDevMode } from '../devtools'
 
 const modeOptions: MoveMode[] = ['DRY_RUN', 'CONFIRM', 'AUTO']
 const fieldOrder: KeywordFilterField[] = ['subject', 'sender', 'body']
@@ -221,6 +222,7 @@ export default function SettingsPage(): JSX.Element {
     error: appConfigError,
     refresh: refreshAppConfig,
   } = useAppConfig()
+  const devMode = useDevMode()
   const {
     data: filterActivity,
     loading: activityLoading,
@@ -590,6 +592,11 @@ export default function SettingsPage(): JSX.Element {
           <NavLink to="/settings" className={({ isActive }) => `nav-link${isActive ? ' active' : ''}`}>
             Einstellungen
           </NavLink>
+          {devMode && (
+            <NavLink to="/dev" className={({ isActive }) => `nav-link${isActive ? ' active' : ''}`}>
+              Dev-Mode
+            </NavLink>
+          )}
         </nav>
       </header>
 

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -500,6 +500,11 @@ button.link {
   color: #c81e1e;
 }
 
+.status-banner.warning {
+  background: #fef3c7;
+  color: #b45309;
+}
+
 .folder-panel,
 .suggestions,
 .pending-overview {
@@ -1363,6 +1368,152 @@ button.link {
 
 .dev-entry.ai {
   border-color: rgba(16, 185, 129, 0.5);
+}
+
+.dev-mode-main {
+  padding: 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.dev-mode-grid {
+  display: grid;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.dev-card {
+  background: #ffffff;
+  border-radius: 20px;
+  padding: 24px;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.dev-card header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.dev-card header h2 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.dev-card header span {
+  font-size: 13px;
+  color: #64748b;
+}
+
+.dev-card dl {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.dev-card dl > div {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.dev-card dt {
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.dev-card dd {
+  margin: 0;
+  color: #475569;
+  text-align: right;
+  word-break: break-word;
+}
+
+.dev-card-block {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.dev-models {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.dev-model {
+  border-radius: 16px;
+  padding: 16px;
+  background: #f8fafc;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.dev-model.ready {
+  background: rgba(236, 253, 245, 0.6);
+  border-color: rgba(34, 197, 94, 0.4);
+}
+
+.dev-model.missing {
+  background: rgba(254, 242, 242, 0.6);
+  border-color: rgba(248, 113, 113, 0.4);
+}
+
+.dev-model header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.dev-model header strong {
+  font-size: 15px;
+}
+
+.dev-model header span {
+  font-size: 12px;
+  color: #64748b;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.dev-model dl {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.dev-model dt {
+  font-size: 12px;
+  color: #475569;
+}
+
+.dev-model dd {
+  margin: 0;
+  font-size: 12px;
+  color: #0f172a;
+  text-align: left;
+  word-break: break-word;
+}
+
+@media (max-width: 900px) {
+  .dev-mode-main {
+    padding: 24px 16px;
+  }
+
+  .dev-card {
+    border-radius: 16px;
+    padding: 20px;
+  }
 }
 
 .suggestion-details .score {


### PR DESCRIPTION
## Summary
- add a dedicated Developer Console route that exposes backend runtime configuration, Ollama status and frontend environment data when dev mode is active
- surface the dev console in the navigation for dashboard and settings views and guard it behind the dev-mode flag
- export API/stream endpoints for reuse and style the new diagnostics layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4ef35efb08328ae35b8ff6675f0bd