### PR TITLE
Handle missing Ollama host gracefully and add model deletion controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Die Keyword-Analyse entscheidet zunächst, ob eine Nachricht anhand definierter 
 | `GET`   | `/api/filters/activity` | Statistik zu Filtertreffern (Gesamt, letzte 24 h, letzte Aktionen) |
 | `GET`   | `/api/ollama`       | Aktuelle Erreichbarkeit des Ollama-Hosts und Modellstatus |
 | `POST`  | `/api/ollama/pull`  | Startet das Nachladen eines Modells (JSON: `{ "model": "name", "purpose": "classifier" }`) |
+| `POST`  | `/api/ollama/delete`| Löscht ein Modell vom Ollama-Host (JSON: `{ "model": "name" }`) |
 | `GET`   | `/api/config`       | Liefert Laufzeitkonfiguration (Modus, Modell, Tag-Namen, Listenlimit) |
 | `PUT`   | `/api/config`       | Aktualisiert Modus, Sprachmodell und IMAP-Tags (Teil-Update möglich) |
 | `POST`  | `/api/decide`       | Nimmt Entscheidung für einen Vorschlag entgegen |

--- a/backend/ollama_service.py
+++ b/backend/ollama_service.py
@@ -105,6 +105,11 @@ async def _get_progress(normalized: str) -> ModelPullProgress | None:
         return _PULL_PROGRESS.get(normalized)
 
 
+async def _discard_progress(normalized: str) -> None:
+    async with _PROGRESS_LOCK:
+        _PULL_PROGRESS.pop(normalized, None)
+
+
 def _failure_status(message: str) -> OllamaStatus:
     models = [
         OllamaModelStatus(
@@ -463,6 +468,30 @@ async def refresh_status(pull_missing: bool = False) -> OllamaStatus:
         global _STATUS_CACHE
         _STATUS_CACHE = status
         return status
+
+
+async def delete_model(model: str) -> None:
+    """Delete the given model from the Ollama host and clear cached metadata."""
+
+    normalized = _normalise_model_name(model)
+    timeout = httpx.Timeout(60.0, connect=15.0)
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        response = await client.post(
+            f"{S.OLLAMA_HOST}/api/delete",
+            json={"name": normalized},
+        )
+        response.raise_for_status()
+        try:
+            payload = response.json()
+        except ValueError:
+            payload = None
+    if isinstance(payload, dict):
+        if payload.get("deleted") is False:
+            message = str(payload.get("error") or payload)
+            raise RuntimeError(message)
+    async with _MODEL_INFO_LOCK:
+        _MODEL_INFO_CACHE.pop(normalized, None)
+    await _discard_progress(normalized)
 
 
 async def ensure_ollama_ready() -> OllamaStatus:

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -111,6 +111,10 @@ export interface OllamaPullRequest {
   purpose?: OllamaModelPurpose
 }
 
+export interface OllamaDeleteRequest {
+  model: string
+}
+
 export interface FolderChildConfig {
   name: string
   description?: string | null
@@ -417,6 +421,13 @@ export async function getOllamaStatus(): Promise<OllamaStatus> {
 
 export async function pullOllamaModel(payload: OllamaPullRequest): Promise<OllamaStatus> {
   return request<OllamaStatus>('/api/ollama/pull', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  })
+}
+
+export async function deleteOllamaModel(payload: OllamaDeleteRequest): Promise<OllamaStatus> {
+  return request<OllamaStatus>('/api/ollama/delete', {
     method: 'POST',
     body: JSON.stringify(payload),
   })

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -375,6 +375,11 @@ input {
   align-items: center;
 }
 
+.ollama-model-detail-actions {
+  display: flex;
+  gap: 8px;
+}
+
 .model-name,
 .model-purpose {
   font-weight: 600;


### PR DESCRIPTION
## Summary
- ensure the backend keeps serving IMAP endpoints even when the Ollama host is unavailable
- expose a new `/api/ollama/delete` endpoint and surface per-model delete actions in the settings UI
- refresh Ollama status handling on the frontend and document the new management workflow

## Testing
- python -m compileall backend
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e51248cb14832894135ee16906b1ac