### PR TITLE
Fix JSX closing tags in suggestion metrics block

### DIFF
--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -535,7 +535,7 @@ export default function DashboardPage(): JSX.Element {
               </button>
             </div>
           </div>
-        )}
+        </div>
       </header>
       {dashboardView === 'mail' ? (
         <>
@@ -667,47 +667,47 @@ export default function DashboardPage(): JSX.Element {
                   {suggestionStats && (
                     <div className="suggestions-metrics">
                       <div className="suggestion-metric open">
-                    <span className="label">Zu bearbeiten</span>
-                    <strong>{suggestionStats.openCount}</strong>
-                    <span className="muted">offene Nachrichten</span>
-                  </div>
-                  <div className="suggestion-metric processed">
-                    <span className="label">Bereits bearbeitet</span>
-                    <strong>{suggestionStats.decidedCount}</strong>
-                    <span className="muted">von {suggestionStats.totalCount} analysierten Mails</span>
-                  </div>
-                  <div className={`suggestion-metric error ${suggestionStats.errorCount === 0 ? 'empty' : ''}`}>
-                    <span className="label">Fehler</span>
-                    <strong>{suggestionStats.errorCount}</strong>
-                    <span className="muted">Mails mit Fehlern</span>
-                  </div>
-                </div>
-              )}
-              {loading && <div className="placeholder">Bitte warten…</div>}
-              {!loading && !suggestions.length && (
-                <div className="placeholder">
-                  {suggestionScope === 'open'
-                    ? 'Super! Alles abgearbeitet.'
-                    : 'Es liegen noch keine analysierten Vorschläge vor.'}
-                </div>
-              )}
-              {!loading && suggestions.length > 0 && (
-                <ul className="suggestion-list">
-                  {suggestions.map((item: Suggestion) => (
-                    <SuggestionCard
-                      key={item.message_uid}
-                      suggestion={item}
-                      onActionComplete={handleSuggestionUpdate}
-                      tagSlots={appConfig?.tag_slots}
-                      availableFolders={availableFolders}
-                      onFolderCreated={handleFolderCreated}
-                      analysisModule={analysisModule}
-                    />
-                  ))}
-                </ul>
-              )}
-            </section>
-          ) : (
+                        <span className="label">Zu bearbeiten</span>
+                        <strong>{suggestionStats.openCount}</strong>
+                        <span className="muted">offene Nachrichten</span>
+                      </div>
+                      <div className="suggestion-metric processed">
+                        <span className="label">Bereits bearbeitet</span>
+                        <strong>{suggestionStats.decidedCount}</strong>
+                        <span className="muted">von {suggestionStats.totalCount} analysierten Mails</span>
+                      </div>
+                      <div className={`suggestion-metric error ${suggestionStats.errorCount === 0 ? 'empty' : ''}`}>
+                        <span className="label">Fehler</span>
+                        <strong>{suggestionStats.errorCount}</strong>
+                        <span className="muted">Mails mit Fehlern</span>
+                      </div>
+                    </div>
+                  )}
+                  {loading && <div className="placeholder">Bitte warten…</div>}
+                  {!loading && !suggestions.length && (
+                    <div className="placeholder">
+                      {suggestionScope === 'open'
+                        ? 'Super! Alles abgearbeitet.'
+                        : 'Es liegen noch keine analysierten Vorschläge vor.'}
+                    </div>
+                  )}
+                  {!loading && suggestions.length > 0 && (
+                    <ul className="suggestion-list">
+                      {suggestions.map((item: Suggestion) => (
+                        <SuggestionCard
+                          key={item.message_uid}
+                          suggestion={item}
+                          onActionComplete={handleSuggestionUpdate}
+                          tagSlots={appConfig?.tag_slots}
+                          availableFolders={availableFolders}
+                          onFolderCreated={handleFolderCreated}
+                          analysisModule={analysisModule}
+                        />
+                      ))}
+                    </ul>
+                  )}
+                </section>
+              ) : (
             <section className="suggestions">
               <div className="suggestions-header">
                 <h2>Keine KI-Vorschläge im Statischen Modul</h2>


### PR DESCRIPTION
## Summary
- realign the JSX for the suggestion metrics section so all conditional elements stay within the suggestions container
- ensure the Dashboard layout closes every div and fragment correctly to satisfy Vite's parser

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e54c6051a88328bff1a7a72aa8a50d