### PR TITLE
Add account settings for IMAP/CalDAV and fix Ollama model detection

### DIFF
--- a/backend/classifier.py
+++ b/backend/classifier.py
@@ -27,7 +27,7 @@ from configuration import (
 )
 from ollama_service import get_model_context_window
 from settings import S
-from runtime_settings import resolve_classifier_model
+from runtime_settings import resolve_classifier_model, resolve_mailbox_inbox
 
 
 logger = logging.getLogger(__name__)
@@ -281,7 +281,7 @@ def _match_catalog_path(name: str, catalog_index: Sequence[Tuple[str, str]] | No
             return []
         seen: set[str] = set()
         inbox_aliases = {"inbox"}
-        inbox_value = (S.IMAP_INBOX or "").strip().lower()
+        inbox_value = resolve_mailbox_inbox().strip().lower()
         if inbox_value:
             inbox_aliases.add(inbox_value)
         joined = "/".join(segments)
@@ -1433,7 +1433,7 @@ def _base_parent_segment(parent_hint: str | None) -> str:
     ensured = ensure_top_level_parent(parent_hint)
     if ensured:
         return ensured
-    fallback = (S.IMAP_INBOX or "INBOX").strip() or "INBOX"
+    fallback = resolve_mailbox_inbox()
     fallback_ensured = ensure_top_level_parent(fallback)
     return fallback_ensured or fallback
 

--- a/backend/database.py
+++ b/backend/database.py
@@ -237,6 +237,25 @@ def set_calendar_settings_entry(values: Dict[str, Any]) -> None:
     _set_config_value("CALENDAR_SETTINGS", payload)
 
 
+def get_mailbox_settings_entry() -> Dict[str, Any]:
+    raw = _get_config_value("MAILBOX_SETTINGS")
+    if not isinstance(raw, str) or not raw.strip():
+        return {}
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        logger.warning("Persistierte Mailbox-Konfiguration konnte nicht geparst werden.")
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    return data
+
+
+def set_mailbox_settings_entry(values: Dict[str, Any]) -> None:
+    payload = json.dumps(values, ensure_ascii=False)
+    _set_config_value("MAILBOX_SETTINGS", payload)
+
+
 def calendar_event_by_uid(message_uid: str, event_uid: str) -> Optional[CalendarEventEntry]:
     with get_session() as ses:
         return ses.exec(

--- a/backend/imap_worker.py
+++ b/backend/imap_worker.py
@@ -38,6 +38,7 @@ from mailbox import (
     move_message,
 )
 from models import Suggestion
+from runtime_settings import resolve_mailbox_inbox
 from ollama_service import ensure_ollama_ready
 from settings import S
 from runtime_settings import (
@@ -143,7 +144,8 @@ async def one_shot_scan(folders: Sequence[str] | None = None) -> int:
         target_folders: Sequence[str] = [str(folder) for folder in folders if str(folder).strip()]
     else:
         configured = get_monitored_folders()
-        target_folders = configured or [S.IMAP_INBOX]
+        inbox = resolve_mailbox_inbox()
+        target_folders = configured or [inbox]
     messages = await asyncio.to_thread(fetch_recent_messages, target_folders)
     all_folders = await asyncio.to_thread(list_folders)
     processed = 0

--- a/backend/mail_settings.py
+++ b/backend/mail_settings.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict
+
+from imapclient import IMAPClient
+
+from database import get_mailbox_settings_entry, set_mailbox_settings_entry
+from settings import S
+
+
+@dataclass
+class MailboxSettings:
+    host: str
+    port: int
+    username: str
+    inbox: str
+    use_ssl: bool
+    process_only_seen: bool
+    since_days: int
+    password: str | None = None
+
+    def sanitized(self) -> "MailboxSettings":
+        return MailboxSettings(
+            host=self.host,
+            port=self.port,
+            username=self.username,
+            inbox=self.inbox,
+            use_ssl=self.use_ssl,
+            process_only_seen=self.process_only_seen,
+            since_days=self.since_days,
+            password=None,
+        )
+
+
+def _base_defaults() -> Dict[str, Any]:
+    return {
+        "host": S.IMAP_HOST or "localhost",
+        "port": int(getattr(S, "IMAP_PORT", 993) or 993),
+        "username": S.IMAP_USERNAME or "",
+        "password": S.IMAP_PASSWORD or "",
+        "inbox": S.IMAP_INBOX or "INBOX",
+        "use_ssl": bool(getattr(S, "IMAP_USE_SSL", True)),
+        "process_only_seen": bool(getattr(S, "PROCESS_ONLY_SEEN", False)),
+        "since_days": int(getattr(S, "SINCE_DAYS", 30) or 30),
+    }
+
+
+def _normalize_port(value: Any) -> int:
+    try:
+        port = int(value)
+    except (TypeError, ValueError):
+        raise ValueError("Port muss eine Zahl sein.") from None
+    if port <= 0 or port > 65535:
+        raise ValueError("Port muss zwischen 1 und 65535 liegen.")
+    return port
+
+
+def _normalize_since_days(value: Any) -> int:
+    try:
+        days = int(value)
+    except (TypeError, ValueError):
+        raise ValueError("Zeitraum (Tage) muss eine Zahl sein.") from None
+    if days < 0:
+        raise ValueError("Zeitraum (Tage) darf nicht negativ sein.")
+    return days
+
+
+def load_mailbox_settings(include_password: bool = False) -> MailboxSettings:
+    stored = _base_defaults()
+    overrides = get_mailbox_settings_entry()
+    if overrides:
+        stored.update({key: value for key, value in overrides.items() if value is not None})
+    password_value = str(stored.get("password") or "").strip()
+    try:
+        port = _normalize_port(stored.get("port", 993))
+    except ValueError:
+        port = 993
+    try:
+        since_days = _normalize_since_days(stored.get("since_days", 30))
+    except ValueError:
+        since_days = 30
+    settings = MailboxSettings(
+        host=str(stored.get("host") or "").strip() or "localhost",
+        port=port,
+        username=str(stored.get("username") or "").strip(),
+        inbox=str(stored.get("inbox") or "").strip() or "INBOX",
+        use_ssl=bool(stored.get("use_ssl", True)),
+        process_only_seen=bool(stored.get("process_only_seen", False)),
+        since_days=since_days,
+        password=password_value if include_password and password_value else None,
+    )
+    return settings
+
+
+def persist_mailbox_settings(
+    *,
+    host: str,
+    port: int,
+    username: str,
+    inbox: str,
+    use_ssl: bool,
+    process_only_seen: bool,
+    since_days: int,
+    password: str | None,
+    clear_password: bool,
+) -> MailboxSettings:
+    normalized_host = host.strip()
+    if not normalized_host:
+        raise ValueError("Host darf nicht leer sein.")
+    normalized_username = username.strip()
+    if not normalized_username:
+        raise ValueError("Benutzername darf nicht leer sein.")
+    normalized_inbox = inbox.strip() or "INBOX"
+    normalized_port = _normalize_port(port)
+    normalized_since = _normalize_since_days(since_days)
+
+    current = get_mailbox_settings_entry()
+    payload: Dict[str, Any] = {
+        "host": normalized_host,
+        "port": normalized_port,
+        "username": normalized_username,
+        "inbox": normalized_inbox,
+        "use_ssl": bool(use_ssl),
+        "process_only_seen": bool(process_only_seen),
+        "since_days": normalized_since,
+    }
+    if clear_password:
+        payload["password"] = ""
+    elif password is not None:
+        payload["password"] = password
+    elif current and "password" in current:
+        payload["password"] = current.get("password", "")
+    set_mailbox_settings_entry(payload)
+    return load_mailbox_settings(include_password=True)
+
+
+def verify_mailbox_connection(
+    *,
+    host: str,
+    port: int,
+    username: str,
+    password: str,
+    inbox: str,
+    use_ssl: bool,
+) -> None:
+    normalized_host = host.strip()
+    if not normalized_host:
+        raise ValueError("Host darf nicht leer sein.")
+    normalized_username = username.strip()
+    if not normalized_username:
+        raise ValueError("Benutzername darf nicht leer sein.")
+    normalized_inbox = inbox.strip() or "INBOX"
+    normalized_port = _normalize_port(port)
+    if not password:
+        raise ValueError("Passwort darf nicht leer sein.")
+
+    client = IMAPClient(normalized_host, port=normalized_port, ssl=bool(use_ssl))
+    try:
+        client.login(normalized_username, password)
+        client.select_folder(normalized_inbox)
+    finally:
+        try:
+            client.logout()
+        except Exception:
+            pass

--- a/backend/ollama_service.py
+++ b/backend/ollama_service.py
@@ -168,9 +168,24 @@ def _match_model_entry(
     entries: Iterable[Dict[str, Any]],
 ) -> Dict[str, Any] | None:
     candidate_set = {value.strip() for value in candidates if value}
+    normalized_candidates = {_normalise_model_name(value) for value in candidate_set if value}
+    base_candidates = {
+        value.split(":", 1)[0].strip()
+        for value in candidate_set
+        if value and value.split(":", 1)[0].strip()
+    }
     for entry in entries:
         value = str(entry.get("model") or entry.get("name") or "").strip()
-        if value in candidate_set:
+        if not value:
+            continue
+        normalized = _normalise_model_name(value)
+        base = value.split(":", 1)[0].strip()
+        if (
+            value in candidate_set
+            or normalized in candidate_set
+            or normalized in normalized_candidates
+            or base in base_candidates
+        ):
             return entry
     return None
 

--- a/backend/runtime_settings.py
+++ b/backend/runtime_settings.py
@@ -11,6 +11,7 @@ from database import (
     get_mailbox_tags,
     get_mode_override,
 )
+from mail_settings import MailboxSettings, load_mailbox_settings
 
 
 def resolve_move_mode() -> str:
@@ -39,6 +40,20 @@ def resolve_mailbox_tags() -> Tuple[str | None, str | None, str | None]:
     processed = stored_processed if stored_processed is not None else (S.IMAP_PROCESSED_TAG or None)
     prefix = stored_prefix if stored_prefix is not None else (S.IMAP_AI_TAG_PREFIX or None)
     return protected, processed, prefix
+
+
+def resolve_mailbox_settings(include_password: bool = False) -> MailboxSettings:
+    """Return the active mailbox connection settings including overrides."""
+
+    return load_mailbox_settings(include_password=include_password)
+
+
+def resolve_mailbox_inbox() -> str:
+    """Return the configured inbox folder name with sane defaults."""
+
+    settings = load_mailbox_settings(include_password=False)
+    inbox = settings.inbox.strip() if settings.inbox else ""
+    return inbox or "INBOX"
 
 
 def resolve_analysis_module() -> str:

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -203,6 +203,44 @@ export interface CalendarConnectionTestResponse {
   message?: string | null
 }
 
+export interface MailboxSettings {
+  host: string
+  port: number
+  username: string
+  inbox: string
+  use_ssl: boolean
+  process_only_seen: boolean
+  since_days: number
+  has_password: boolean
+}
+
+export interface MailboxSettingsUpdateRequest {
+  host: string
+  port: number
+  username: string
+  inbox: string
+  use_ssl: boolean
+  process_only_seen: boolean
+  since_days: number
+  password?: string | null
+  clear_password?: boolean
+}
+
+export interface MailboxConnectionTestRequest {
+  host?: string
+  port?: number
+  username?: string
+  password?: string | null
+  inbox?: string
+  use_ssl?: boolean
+  use_stored_password?: boolean
+}
+
+export interface MailboxConnectionTestResponse {
+  ok: boolean
+  message?: string | null
+}
+
 export interface TagExample {
   message_uid: string
   subject: string
@@ -679,6 +717,28 @@ export async function testCalendarConnection(
   payload: CalendarConnectionTestRequest,
 ): Promise<CalendarConnectionTestResponse> {
   return request<CalendarConnectionTestResponse>('/api/calendar/config/test', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  })
+}
+
+export async function getMailboxSettings(): Promise<MailboxSettings> {
+  return request<MailboxSettings>('/api/mailbox/config')
+}
+
+export async function updateMailboxSettings(
+  payload: MailboxSettingsUpdateRequest,
+): Promise<MailboxSettings> {
+  return request<MailboxSettings>('/api/mailbox/config', {
+    method: 'PUT',
+    body: JSON.stringify(payload),
+  })
+}
+
+export async function testMailboxConnection(
+  payload: MailboxConnectionTestRequest,
+): Promise<MailboxConnectionTestResponse> {
+  return request<MailboxConnectionTestResponse>('/api/mailbox/config/test', {
     method: 'POST',
     body: JSON.stringify(payload),
   })


### PR DESCRIPTION
## Summary
- add persistence helpers and API endpoints for mailbox settings including an IMAP connection test
- reorganize the settings UI into a new "Konten" tab that manages email and calendar credentials together
- improve Ollama model detection for installed variants and document the new workflow

## Testing
- python -m compileall backend
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e560e5d8848328b59f3b574ef681d7