### PR TITLE
Handle Ollama delete endpoint changes

### DIFF
--- a/backend/ollama_service.py
+++ b/backend/ollama_service.py
@@ -524,25 +524,62 @@ async def refresh_status(pull_missing: bool = False) -> OllamaStatus:
         return status
 
 
+def _coerce_json_dict(response: httpx.Response) -> Dict[str, Any] | None:
+    try:
+        payload = response.json()
+    except ValueError:
+        return None
+    if isinstance(payload, dict):
+        return payload
+    return None
+
+
+def _extract_delete_error(response: httpx.Response, normalized: str) -> str:
+    payload = _coerce_json_dict(response)
+    if payload:
+        message = payload.get("error") or payload.get("message") or payload.get("status")
+        if message:
+            return str(message)
+    text = response.text.strip()
+    if response.status_code == 404:
+        return f"Modell '{normalized}' wurde nicht gefunden"
+    if text:
+        return text
+    return f"HTTP {response.status_code}"
+
+
+async def _delete_model_legacy(client: httpx.AsyncClient, normalized: str) -> Dict[str, Any] | None:
+    response = await client.post(
+        f"{S.OLLAMA_HOST}/api/delete",
+        json={"name": normalized},
+    )
+    try:
+        response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        message = _extract_delete_error(response, normalized)
+        raise RuntimeError(message) from exc
+    return _coerce_json_dict(response)
+
+
 async def delete_model(model: str) -> None:
     """Delete the given model from the Ollama host and clear cached metadata."""
 
     normalized = _normalise_model_name(model)
     timeout = httpx.Timeout(60.0, connect=15.0)
     async with httpx.AsyncClient(timeout=timeout) as client:
-        response = await client.post(
-            f"{S.OLLAMA_HOST}/api/delete",
-            json={"name": normalized},
-        )
-        response.raise_for_status()
-        try:
-            payload = response.json()
-        except ValueError:
-            payload = None
-    if isinstance(payload, dict):
-        if payload.get("deleted") is False:
-            message = str(payload.get("error") or payload)
-            raise RuntimeError(message)
+        response = await client.delete(f"{S.OLLAMA_HOST}/api/tags/{normalized}")
+        if response.status_code == 405:
+            payload = await _delete_model_legacy(client, normalized)
+        else:
+            try:
+                response.raise_for_status()
+            except httpx.HTTPStatusError as exc:
+                message = _extract_delete_error(response, normalized)
+                raise RuntimeError(message) from exc
+            payload = _coerce_json_dict(response)
+    if isinstance(payload, dict) and payload.get("deleted") is False:
+        message = str(payload.get("error") or payload)
+        raise RuntimeError(message)
     async with _MODEL_INFO_LOCK:
         _MODEL_INFO_CACHE.pop(normalized, None)
     await _discard_progress(normalized)

--- a/backend/tests/test_ollama_delete.py
+++ b/backend/tests/test_ollama_delete.py
@@ -1,0 +1,137 @@
+import asyncio
+from collections.abc import Sequence
+from typing import Any, Dict, List
+
+import httpx
+import pytest
+
+
+class DummyResponse:
+    def __init__(
+        self,
+        method: str,
+        url: str,
+        status_code: int,
+        *,
+        payload: Dict[str, Any] | None = None,
+        text: str = "",
+    ) -> None:
+        self.status_code = status_code
+        self._payload = payload
+        self._text = text
+        self.request = httpx.Request(method, url)
+
+    def json(self) -> Dict[str, Any]:
+        if self._payload is None:
+            raise ValueError("no json")
+        return self._payload
+
+    @property
+    def text(self) -> str:
+        return self._text
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError("error", request=self.request, response=self)
+
+
+class DummyClient:
+    def __init__(
+        self,
+        *,
+        delete_plan: Sequence[Dict[str, Any]] | None = None,
+        post_plan: Sequence[Dict[str, Any]] | None = None,
+    ) -> None:
+        self.delete_plan: List[Dict[str, Any]] = list(delete_plan or [])
+        self.post_plan: List[Dict[str, Any]] = list(post_plan or [])
+        self.delete_calls: List[str] = []
+        self.post_calls: List[tuple[str, Dict[str, Any]]] = []
+
+    async def __aenter__(self) -> "DummyClient":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+    async def delete(self, url: str) -> DummyResponse:
+        self.delete_calls.append(url)
+        plan = self.delete_plan.pop(0) if self.delete_plan else {}
+        status = int(plan.get("status", 204))
+        payload = plan.get("payload")
+        text = plan.get("text", "")
+        return DummyResponse("DELETE", url, status, payload=payload, text=text)
+
+    async def post(self, url: str, *, json: Dict[str, Any]) -> DummyResponse:
+        self.post_calls.append((url, json))
+        plan = self.post_plan.pop(0) if self.post_plan else {}
+        status = int(plan.get("status", 200))
+        payload = plan.get("payload")
+        text = plan.get("text", "")
+        return DummyResponse("POST", url, status, payload=payload, text=text)
+
+
+def _install_client(monkeypatch, ollama_service, client: DummyClient) -> None:
+    def _factory(*args, **kwargs):
+        return client
+
+    monkeypatch.setattr(ollama_service.httpx, "AsyncClient", _factory)
+
+
+def test_delete_model_prefers_delete_endpoint(backend_env, monkeypatch):
+    ollama_service = backend_env["ollama_service"]
+    normalized = ollama_service._normalise_model_name("llama2")
+    client = DummyClient(delete_plan=[{"status": 204}])
+    _install_client(monkeypatch, ollama_service, client)
+
+    asyncio.run(ollama_service.delete_model("llama2"))
+
+    assert client.delete_calls == [f"http://ollama:11434/api/tags/{normalized}"]
+    assert client.post_calls == []
+
+
+def test_delete_model_falls_back_to_legacy_post(backend_env, monkeypatch):
+    ollama_service = backend_env["ollama_service"]
+    normalized = ollama_service._normalise_model_name("mistral")
+    client = DummyClient(
+        delete_plan=[{"status": 405}],
+        post_plan=[{"status": 200, "payload": {"deleted": True}}],
+    )
+    _install_client(monkeypatch, ollama_service, client)
+
+    asyncio.run(ollama_service.delete_model("mistral"))
+
+    assert client.delete_calls == [f"http://ollama:11434/api/tags/{normalized}"]
+    assert client.post_calls == [
+        ("http://ollama:11434/api/delete", {"name": normalized}),
+    ]
+
+
+def test_delete_model_raises_for_missing_model(backend_env, monkeypatch):
+    ollama_service = backend_env["ollama_service"]
+    normalized = ollama_service._normalise_model_name("unknown")
+    client = DummyClient(delete_plan=[{"status": 404}])
+    _install_client(monkeypatch, ollama_service, client)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        asyncio.run(ollama_service.delete_model("unknown"))
+
+    assert f"Modell '{normalized}'" in str(excinfo.value)
+    assert client.post_calls == []
+
+
+def test_delete_model_propagates_legacy_error(backend_env, monkeypatch):
+    ollama_service = backend_env["ollama_service"]
+    normalized = ollama_service._normalise_model_name("broken")
+    client = DummyClient(
+        delete_plan=[{"status": 405}],
+        post_plan=[{"status": 500, "payload": {"error": "kaputt"}}],
+    )
+    _install_client(monkeypatch, ollama_service, client)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        asyncio.run(ollama_service.delete_model("broken"))
+
+    assert "kaputt" in str(excinfo.value)
+    assert client.post_calls == [
+        ("http://ollama:11434/api/delete", {"name": normalized}),
+    ]

--- a/backend/tests/test_worker_llm_ready.py
+++ b/backend/tests/test_worker_llm_ready.py
@@ -1,0 +1,60 @@
+import importlib
+
+
+def _get_helper_modules():
+    ollama_service = importlib.import_module("ollama_service")
+    imap_worker = importlib.import_module("imap_worker")
+    return ollama_service, imap_worker
+
+
+def test_ollama_requirements_fail_when_unreachable(backend_env):
+    ollama_service, imap_worker = _get_helper_modules()
+    status = ollama_service.OllamaStatus(host="http://ollama", reachable=False, models=[])
+    assert imap_worker._ollama_requirements_met(status) is False
+
+
+def test_ollama_requirements_fail_when_models_missing(backend_env):
+    ollama_service, imap_worker = _get_helper_modules()
+
+    status = ollama_service.OllamaStatus(
+        host="http://ollama",
+        reachable=True,
+        models=[
+            ollama_service.OllamaModelStatus(
+                name="llama3",
+                normalized_name="llama3:latest",
+                purpose="classifier",
+                available=False,
+            ),
+            ollama_service.OllamaModelStatus(
+                name="nomic-embed-text",
+                normalized_name="nomic-embed-text:latest",
+                purpose="embedding",
+                available=True,
+            ),
+        ],
+    )
+
+    assert imap_worker._ollama_requirements_met(status) is False
+
+    status.models[0].available = True
+    assert imap_worker._ollama_requirements_met(status) is True
+
+
+def test_ollama_requirements_allow_custom_models_only(backend_env):
+    ollama_service, imap_worker = _get_helper_modules()
+
+    status = ollama_service.OllamaStatus(
+        host="http://ollama",
+        reachable=True,
+        models=[
+            ollama_service.OllamaModelStatus(
+                name="custom-model",
+                normalized_name="custom-model:latest",
+                purpose="custom",
+                available=True,
+            )
+        ],
+    )
+
+    assert imap_worker._ollama_requirements_met(status) is True


### PR DESCRIPTION
## Summary
- update the Ollama deletion flow to prefer the DELETE /api/tags endpoint, fall back to the legacy API, and surface clearer error messages
- add regression tests that cover the preferred path, legacy fallback, missing models, and legacy error propagation

## Testing
- python -m compileall backend
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68e5df2be9788328b17f489114cae38f