### PR TITLE
Fix pending mail limits, refresh analysis controls, and restore dashboard UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,8 +147,8 @@ Die FastAPI-Anwendung lädt Konfigurationen aus `.env` über [`backend/settings.
   (Move-Modus, Analyse-Modul, IMAP-Tags, Pending-Limit, Katalog-Zuschnitt), den aktuellen Ollama-Status inklusive Modellauflistung
   und die aktiven Frontend-Umgebungswerte (`VITE_API_BASE`, `VITE_DEV_MODE`, Build-Typ, Stream-URL). Optional kann das Frontend
   per `VITE_DEV_MODE=true` (in `frontend/.env`) unabhängig vom Backend gestartet werden.
-- Über `/api/scan/start`, `/api/scan/stop` und `/api/scan/status` steuerst du den kontinuierlichen Analyse-Controller. Das Frontend bietet zusätzlich einen Button „Einmalige Analyse“ (via `/api/rescan`), sodass sich eine sofortige Auswertung ohne Daueranalyse starten lässt. Laufende Einmalanalysen lassen sich über „Analyse stoppen“ abbrechen; das Backend verwirft dabei den aktiven Scanauftrag.
-- Laufende Dauer-Analysen blockieren den Einmal-Modus, bis sie gestoppt sind; parallel bleiben „Analyse starten“ und „Analyse stoppen“ für die kontinuierliche Ausführung verfügbar.
+- Über `/api/scan/start`, `/api/scan/stop` und `/api/scan/status` steuerst du den kontinuierlichen Analyse-Controller. Das Frontend bietet getrennte Aktionen „Einzelanalyse starten“ (via `/api/rescan`) und „Daueranalyse starten“, sodass sich spontane Auswertungen ohne dauerhaften Scan auslösen lassen. Laufende Einzelanalysen lassen sich über „Analyse stoppen“ abbrechen; das Backend verwirft dabei den aktiven Scanauftrag.
+- Laufende Daueranalysen blockieren die Einzelanalyse, bis sie gestoppt sind; parallel bleiben „Daueranalyse starten“ und „Analyse stoppen“ für die kontinuierliche Ausführung verfügbar.
 - Die Ordnerauswahl im Dashboard stellt die überwachten IMAP-Ordner als aufklappbaren Baum dar. Der Filter hebt Treffer farblich hervor und öffnet automatisch die relevanten Äste, sodass komplexe Hierarchien schneller angepasst werden können.
 
 ### Keyword-Filter & Direktzuordnung

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -222,6 +222,22 @@ export default function DashboardPage(): JSX.Element {
     scanStateRef.current = { auto: autoActive, manual: manualActive }
   }, [scanStatus?.active, scanStatus?.rescan_active, rescanBusy, refreshPendingOverview])
 
+  const refreshIndicators = useCallback(async () => {
+    const tasks: Promise<unknown>[] = []
+    if (showLlMSuggestions) {
+      tasks.push(refresh())
+    }
+    if (showPendingPanel) {
+      tasks.push(refreshPendingOverview())
+    }
+    if (showAutomationCard) {
+      tasks.push(refreshFilterActivity())
+    }
+    if (tasks.length > 0) {
+      await Promise.allSettled(tasks)
+    }
+  }, [refresh, refreshFilterActivity, refreshPendingOverview, showAutomationCard, showLlMSuggestions, showPendingPanel])
+
   const handleStartScan = async () => {
     setScanBusy(true)
     try {
@@ -230,14 +246,14 @@ export default function DashboardPage(): JSX.Element {
       setScanStatus(response.status)
       setStatus({
         kind: response.started ? 'success' : 'info',
-        message: response.started ? 'Analyse gestartet.' : 'Analyse läuft bereits.',
+        message: response.started ? 'Daueranalyse gestartet.' : 'Daueranalyse läuft bereits.',
       })
       await loadScanStatus()
     } catch (err) {
       setStatus({ kind: 'error', message: `Analyse konnte nicht gestartet werden: ${toMessage(err)}` })
     } finally {
       setScanBusy(false)
-      void refreshPendingOverview().catch(() => undefined)
+      await refreshIndicators()
     }
   }
 
@@ -253,8 +269,8 @@ export default function DashboardPage(): JSX.Element {
         message = 'Es war keine Analyse aktiv.'
       } else if (nextStatus.rescan_cancelled && !nextStatus.rescan_active) {
         message = nextStatus.active
-          ? 'Einmalanalyse gestoppt, Automatik läuft weiter.'
-          : 'Einmalanalyse gestoppt.'
+          ? 'Einzelanalyse gestoppt, Daueranalyse läuft weiter.'
+          : 'Einzelanalyse gestoppt.'
       } else if (!nextStatus.active) {
         message = 'Analyse gestoppt.'
       }
@@ -265,7 +281,7 @@ export default function DashboardPage(): JSX.Element {
     } finally {
       setRescanBusy(false)
       setScanBusy(false)
-      void refreshPendingOverview().catch(() => undefined)
+      await refreshIndicators()
     }
   }
 
@@ -275,25 +291,25 @@ export default function DashboardPage(): JSX.Element {
       const normalizedSelection = normalizeFolders(selectedFolders)
       const response = await rescan(normalizedSelection.length ? normalizedSelection : undefined)
       if (!response.ok && response.cancelled) {
-        setStatus({ kind: 'info', message: 'Einmalanalyse abgebrochen.' })
+        setStatus({ kind: 'info', message: 'Einzelanalyse abgebrochen.' })
       } else if (!response.ok) {
-        setStatus({ kind: 'error', message: 'Einmalanalyse konnte nicht abgeschlossen werden.' })
+        setStatus({ kind: 'error', message: 'Einzelanalyse konnte nicht abgeschlossen werden.' })
       } else {
         const noun = response.new_suggestions === 1 ? 'Vorschlag' : 'Vorschläge'
         setStatus({
           kind: 'success',
-          message: `Einmalanalyse abgeschlossen (${response.new_suggestions} ${noun}).`,
+          message: `Einzelanalyse abgeschlossen (${response.new_suggestions} ${noun}).`,
         })
       }
       void refresh()
     } catch (err) {
-      setStatus({ kind: 'error', message: `Einmalanalyse fehlgeschlagen: ${toMessage(err)}` })
+      setStatus({ kind: 'error', message: `Einzelanalyse fehlgeschlagen: ${toMessage(err)}` })
     } finally {
       setRescanBusy(false)
       await loadScanStatus()
-      void refreshPendingOverview().catch(() => undefined)
+      await refreshIndicators()
     }
-  }, [loadScanStatus, refresh, refreshPendingOverview, selectedFolders])
+  }, [loadScanStatus, refresh, refreshIndicators, selectedFolders])
 
   const dismissStatus = useCallback(() => setStatus(null), [])
 
@@ -307,13 +323,13 @@ export default function DashboardPage(): JSX.Element {
       setSelectedFolders([...normalizedSelected])
       setFolderDraft([...normalizedSelected])
       setStatus({ kind: 'success', message: 'Ordnerauswahl gespeichert.' })
-      void refreshPendingOverview().catch(() => undefined)
+      await refreshIndicators()
     } catch (err) {
       setStatus({ kind: 'error', message: `Ordnerauswahl konnte nicht gespeichert werden: ${toMessage(err)}` })
     } finally {
       setSavingFolders(false)
     }
-  }, [folderDraft, refreshPendingOverview])
+  }, [folderDraft, refreshIndicators])
 
   const handleFolderCreated = useCallback(
     async (folder: string) => {
@@ -369,10 +385,10 @@ export default function DashboardPage(): JSX.Element {
     let statusLabel = 'Gestoppt'
     let statusVariant: 'running' | 'paused' | 'stopped' = 'stopped'
     if (autoActive) {
-      statusLabel = 'Automatik aktiv'
+      statusLabel = 'Daueranalyse aktiv'
       statusVariant = 'running'
     } else if (manualActive) {
-      statusLabel = 'Einmalanalyse aktiv'
+      statusLabel = 'Einzelanalyse aktiv'
       statusVariant = 'running'
     } else if (hasHistory) {
       statusLabel = 'Pausiert'
@@ -442,7 +458,7 @@ export default function DashboardPage(): JSX.Element {
     const cancelSuffix = !manualInfo.active && manualInfo.cancelled ? ' (abgebrochen)' : ''
     analysisFootEntries.push(
       <span key="manual-start">
-        Einmalanalyse: {manualInfo.started}
+        Einzelanalyse: {manualInfo.started}
         {folderSuffix}
         {cancelSuffix}
       </span>,
@@ -458,10 +474,37 @@ export default function DashboardPage(): JSX.Element {
   if (manualInfo.error) {
     analysisFootEntries.push(
       <span key="manual-error" className="analysis-error">
-        Einmalanalyse-Fehler: {manualInfo.error}
+        Einzelanalyse-Fehler: {manualInfo.error}
       </span>,
     )
   }
+
+  useEffect(() => {
+    if (dashboardView !== 'mail') {
+      return
+    }
+    if (!scanSummary.autoActive && !scanSummary.manualActive) {
+      return
+    }
+    if (!showAutomationCard && !showPendingPanel && !showLlMSuggestions) {
+      return
+    }
+    void refreshIndicators()
+    const interval = window.setInterval(() => {
+      void refreshIndicators()
+    }, 5000)
+    return () => {
+      window.clearInterval(interval)
+    }
+  }, [
+    dashboardView,
+    refreshIndicators,
+    scanSummary.autoActive,
+    scanSummary.manualActive,
+    showAutomationCard,
+    showLlMSuggestions,
+    showPendingPanel,
+  ])
 
   return (
     <div className="app-shell">
@@ -495,7 +538,7 @@ export default function DashboardPage(): JSX.Element {
                 <dd>{scanSummary.pollInterval ? `alle ${Math.round(scanSummary.pollInterval)} s` : '–'}</dd>
               </div>
               <div>
-                <dt>Einmalanalyse</dt>
+                <dt>Einzelanalyse</dt>
                 <dd>{manualMetaLabel}</dd>
               </div>
               <div>
@@ -514,23 +557,23 @@ export default function DashboardPage(): JSX.Element {
           <div className="analysis-bar-actions">
             <button
               type="button"
-              className="ghost"
+              className="primary"
               onClick={handleRescan}
               disabled={manualActive || autoActive || scanBusy}
             >
-              {rescanBusy ? 'Analysiere…' : 'Einmalige Analyse'}
+              {rescanBusy ? 'Einzelanalyse läuft…' : 'Einzelanalyse starten'}
             </button>
             <button
               type="button"
-              className="primary"
+              className="secondary"
               onClick={handleStartScan}
               disabled={scanBusy || autoActive || manualActive}
             >
-              {scanBusy && !autoActive ? 'Starte Analyse…' : 'Analyse starten'}
+              {scanBusy && !autoActive ? 'Starte Daueranalyse…' : 'Daueranalyse starten'}
             </button>
             <button
               type="button"
-              className="ghost"
+              className="secondary"
               onClick={handleStopScan}
               disabled={scanBusy || (!autoActive && !manualActive)}
             >

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -697,6 +697,12 @@ button.primary {
   color: white;
 }
 
+button.secondary {
+  background: linear-gradient(135deg, #e2e8f0, #cbd5f5);
+  color: #1f2933;
+  border: 1px solid rgba(148, 163, 184, 0.6);
+}
+
 button.ghost {
   background: transparent;
   border: 1px solid #d5deeb;


### PR DESCRIPTION
## Summary
- prevent the pending mail dashboard from showing more entries than allowed by PENDING_LIST_LIMIT
- rename and restyle the email analysis controls to "Einzelanalyse"/"Daueranalyse" and refresh dashboard indicators while scans run
- document the new button names in the README for clarity
- hoist the shared indicator refresh hook so the dashboard renders without a blank screen

## Testing
- npm run build
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68e5f930c4988328aa5b67e41620ca54