### PR TITLE
Fix Ollama embed fallback and gate confirm-mode tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,9 @@ Die FastAPI-Anwendung lädt Konfigurationen aus `.env` über [`backend/settings.
   Optionskatalog; das LLM muss eine Option auswählen und den Score ≥ `MIN_MATCH_SCORE` halten, andernfalls bleibt der Slot
   leer. Kontext-Tags wie `datum-YYYY-MM-TT` oder `reiseort-ORT` werden nur bei eindeutiger Zuordnung ergänzt.
 - Tagging und Ordnerentscheidungen bleiben getrennt: Tags landen als `IMAP_AI_TAG_PREFIX/slot-option`-Kombination
-  am jeweiligen IMAP-Objekt, während Ordner-Vorschläge weiter bestätigt oder abgelehnt werden können.
+  am jeweiligen IMAP-Objekt, während Ordner-Vorschläge weiter bestätigt oder abgelehnt werden können. Im
+  Confirm-Modus setzt das Backend diese Tags – inklusive `IMAP_PROCESSED_TAG` – erst nach der Freigabe im Dashboard;
+  der Auto-Modus versieht Nachrichten weiterhin unmittelbar mit allen Markierungen.
 
 ### Konfigurierbare Hierarchie & Tag-Slots
 
@@ -134,7 +136,8 @@ Die FastAPI-Anwendung lädt Konfigurationen aus `.env` über [`backend/settings.
 ### Schutz- und Monitoring-Einstellungen
 
 - `IMAP_PROTECTED_TAG` kennzeichnet Nachrichten, die vom Worker übersprungen werden sollen (z. B. manuell markierte Threads).
-- `IMAP_PROCESSED_TAG` wird nach erfolgreicher Verarbeitung automatisch gesetzt und verhindert erneute Scans.
+- `IMAP_PROCESSED_TAG` wird nach erfolgreicher Verarbeitung automatisch gesetzt und verhindert erneute Scans. Im Confirm-Modus
+  geschieht das erst mit der manuellen Bestätigung, damit unbearbeitete Vorschläge im Posteingang unverändert bleiben.
 - Der Tab „Betrieb“ in den Einstellungen bündelt Analyse-Modul, Verarbeitungsmodus und IMAP-Tags; das Dashboard zeigt den gewählten Modus weiterhin an. Die Auswahl des Sprachmodells erfolgt im Tab „KI & Tags“.
 - Die Module steuern, welche Informationen sichtbar sind:
 - **Statisch** setzt ausschließlich auf Keyword-Regeln. KI-Kontexte (Scores, Tag-Vorschläge, Kategorien), Pending-Listen und Vorschlagskarten werden im Dashboard ausgeblendet – ideal, wenn kein LLM verfügbar ist. Der Worker ruft in diesem Modus keine Ollama-Endpunkte auf.

--- a/backend/classifier.py
+++ b/backend/classifier.py
@@ -160,24 +160,7 @@ def build_embedding_prompt(subject: str, sender: str, body: str) -> str:
     return prompt
 
 
-async def embed(prompt: str) -> List[float]:
-    try:
-        async with httpx.AsyncClient(timeout=60) as client:
-            response = await client.post(
-                f"{S.OLLAMA_HOST}/api/embed",
-                json={
-                    "model": S.EMBED_MODEL,
-                    "input": [prompt[: S.EMBED_PROMPT_MAX_CHARS]],
-                },
-            )
-            response.raise_for_status()
-    except httpx.HTTPError as exc:  # pragma: no cover - network interaction
-        logger.warning(
-            "Ollama Embedding fehlgeschlagen (%s): %s", S.OLLAMA_HOST, exc
-        )
-        return []
-
-    data = response.json()
+def _extract_embedding(data: Dict[str, Any]) -> List[float]:
     embedding = data.get("embedding")
     if isinstance(embedding, list):
         if embedding and isinstance(embedding[0], list):
@@ -188,6 +171,52 @@ async def embed(prompt: str) -> List[float]:
         first = embeddings[0]
         if isinstance(first, list):
             return first
+    return []
+
+
+async def embed(prompt: str) -> List[float]:
+    payload = {
+        "model": S.EMBED_MODEL,
+        "input": [prompt[: S.EMBED_PROMPT_MAX_CHARS]],
+    }
+    endpoints = [
+        f"{S.OLLAMA_HOST}/api/embeddings",
+        f"{S.OLLAMA_HOST}/api/embed",
+    ]
+    last_error: Exception | None = None
+
+    try:
+        async with httpx.AsyncClient(timeout=60) as client:
+            for endpoint in endpoints:
+                try:
+                    response = await client.post(endpoint, json=payload)
+                    response.raise_for_status()
+                except httpx.HTTPStatusError as exc:
+                    if exc.response.status_code == 404 and endpoint.endswith("/api/embeddings"):
+                        logger.debug(
+                            "Ollama-Endpoint %s nicht verfügbar (404) – verwende Fallback.",
+                            endpoint,
+                        )
+                        last_error = exc
+                        continue
+                    last_error = exc
+                    break
+                except httpx.HTTPError as exc:  # pragma: no cover - network interaction
+                    last_error = exc
+                    break
+
+                data = response.json()
+                embedding = _extract_embedding(data)
+                if embedding:
+                    return embedding
+                last_error = ValueError("embedding payload missing")
+    except httpx.HTTPError as exc:  # pragma: no cover - network interaction
+        last_error = exc
+
+    if last_error is not None:
+        logger.warning(
+            "Ollama Embedding fehlgeschlagen (%s): %s", S.OLLAMA_HOST, last_error
+        )
     return []
 
 

--- a/backend/imap_worker.py
+++ b/backend/imap_worker.py
@@ -6,7 +6,6 @@ import asyncio
 import email
 import logging
 import os
-import re
 from email import policy
 from typing import Sequence
 
@@ -17,7 +16,6 @@ from classifier import (
     propose_new_folder_if_needed,
     score_profiles,
 )
-from configuration import max_tag_total
 from database import (
     get_monitored_folders,
     is_processed,
@@ -30,13 +28,7 @@ from database import (
     save_suggestion,
 )
 from feedback import update_profiles_on_accept
-from mailbox import (
-    add_message_tag,
-    ensure_folder_path,
-    fetch_recent_messages,
-    list_folders,
-    move_message,
-)
+from mailbox import ensure_folder_path, fetch_recent_messages, list_folders, move_message
 from models import Suggestion
 from runtime_settings import resolve_mailbox_inbox
 from ollama_service import OllamaModelStatus, OllamaStatus, ensure_ollama_ready
@@ -45,61 +37,14 @@ from runtime_settings import (
     analysis_module_uses_filters,
     analysis_module_uses_llm,
     resolve_analysis_module,
-    resolve_mailbox_tags,
     resolve_move_mode,
 )
 from keyword_filters import evaluate_filters
 from utils import extract_text, message_received_at, subject_from, thread_headers
+from tagging_service import apply_suggestion_tags
 
 
 logger = logging.getLogger(__name__)
-
-
-_TAG_SANITIZE_RE = re.compile(r"[^0-9A-Za-z._+/:-]+")
-
-
-def _format_ai_tag(label: str, prefix: str | None) -> str | None:
-    cleaned = label.strip()
-    if not cleaned:
-        return None
-    normalized = re.sub(r"\s+", "-", cleaned)
-    normalized = _TAG_SANITIZE_RE.sub("", normalized)
-    normalized = normalized.strip("-/")[:48]
-    if not normalized:
-        return None
-    if prefix:
-        base = prefix.strip("/")
-        if not base:
-            return normalized
-        return f"{base}/{normalized}"
-    return normalized
-
-
-def _apply_ai_tags(uid: str, folder: str, raw_tags: Sequence[str]) -> None:
-    if not raw_tags:
-        return
-    _, processed_marker, prefix = resolve_mailbox_tags()
-    processed_marker = (processed_marker or "").strip()
-    unique: list[str] = []
-    limit = max_tag_total()
-    for tag in raw_tags:
-        if not isinstance(tag, str):
-            continue
-        formatted = _format_ai_tag(tag, prefix)
-        if not formatted:
-            continue
-        if processed_marker and formatted == processed_marker:
-            continue
-        if formatted in unique:
-            continue
-        unique.append(formatted)
-        if len(unique) >= limit:
-            break
-    if not unique:
-        return
-    logger.debug("Adding AI Tags %s to %s", unique, uid)
-    for tag in unique:
-        add_message_tag(uid, folder, tag)
 
 
 def _should_autostart() -> bool:
@@ -312,13 +257,13 @@ async def handle_message(
         move_status="pending",
     )
     save_suggestion(suggestion)
-    _, processed_tag, _ = resolve_mailbox_tags()
-    if processed_tag:
-        add_message_tag(uid, src_folder, processed_tag)
-    _apply_ai_tags(uid, src_folder, tags)
 
     mode = resolve_move_mode()
-    should_auto_move = mode == "AUTO" and (
+    auto_mode = mode == "AUTO"
+    if auto_mode:
+        apply_suggestion_tags(uid, src_folder, tags, include_processed=True)
+
+    should_auto_move = auto_mode and (
         (match_score >= S.AUTO_THRESHOLD) or bool(thread.get("in_reply_to"))
     )
 

--- a/backend/tagging_service.py
+++ b/backend/tagging_service.py
@@ -1,0 +1,84 @@
+"""Helpers to apply AI and processed tags consistently."""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Iterable, List, Sequence
+
+from configuration import max_tag_total
+from mailbox import add_message_tag
+from runtime_settings import resolve_mailbox_inbox, resolve_mailbox_tags
+
+
+logger = logging.getLogger(__name__)
+
+
+_TAG_SANITIZE_RE = re.compile(r"[^0-9A-Za-z._+/:-]+")
+
+
+def _format_ai_tag(label: str, prefix: str | None) -> str | None:
+    cleaned = label.strip()
+    if not cleaned:
+        return None
+    normalized = re.sub(r"\s+", "-", cleaned)
+    normalized = _TAG_SANITIZE_RE.sub("", normalized)
+    normalized = normalized.strip("-/")[:48]
+    if not normalized:
+        return None
+    if prefix:
+        base = prefix.strip("/")
+        if not base:
+            return normalized
+        return f"{base}/{normalized}"
+    return normalized
+
+
+def _unique_limited(values: Iterable[str], limit: int) -> List[str]:
+    seen: list[str] = []
+    for value in values:
+        if not value:
+            continue
+        if value in seen:
+            continue
+        seen.append(value)
+        if len(seen) >= limit:
+            break
+    return seen
+
+
+def sanitise_ai_tags(raw_tags: Sequence[str] | None) -> List[str]:
+    if not raw_tags:
+        return []
+    _, processed_tag, prefix = resolve_mailbox_tags()
+    processed_value = (processed_tag or "").strip()
+    formatted: List[str] = []
+    for tag in raw_tags:
+        if not isinstance(tag, str):
+            continue
+        candidate = _format_ai_tag(tag, prefix)
+        if not candidate:
+            continue
+        if processed_value and candidate == processed_value:
+            continue
+        formatted.append(candidate)
+    return _unique_limited(formatted, max_tag_total())
+
+
+def apply_suggestion_tags(
+    uid: str,
+    folder: str | None,
+    raw_tags: Sequence[str] | None,
+    *,
+    include_processed: bool = True,
+) -> None:
+    target_folder = folder or resolve_mailbox_inbox()
+    _, processed_tag, _ = resolve_mailbox_tags()
+    processed_value = (processed_tag or "").strip()
+    if include_processed and processed_value:
+        logger.debug("Adding processed tag %s to %s in %s", processed_value, uid, target_folder)
+        add_message_tag(uid, target_folder, processed_value)
+
+    for tag in sanitise_ai_tags(raw_tags):
+        logger.debug("Adding AI tag %s to %s in %s", tag, uid, target_folder)
+        add_message_tag(uid, target_folder, tag)


### PR DESCRIPTION
## Summary
- add a shared tagging helper so only AUTO mode tags immediately while CONFIRM mode waits until approval
- update the Ollama embed call to try the new /api/embeddings endpoint with a legacy fallback
- document the updated confirm-mode tagging behaviour in the README

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68e620e2f5908328a9958543d729797f